### PR TITLE
Major refactor of backbone. Added backbone views cleanup. Added better collection/model error/loading UI handling.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -8,9 +8,9 @@ module.exports = (grunt) ->
       static: "static"
       build: "static/build"
       src: "static/src"
+      html: "static/src/html"
       deploy: "static/dist"
       components: "static/components"
-      html: "static/html"
     
     # Coffeescript Linter
     coffeelint:

--- a/static/html/iframe.html
+++ b/static/html/iframe.html
@@ -74,7 +74,7 @@
     <!--(if target dev)><!-->
       <script>
         jailbreak.env = "LOCAL";
-        jailbreak.api_host = "https://jbapi.net";
+        jailbreak.api_host = "http://localhost:8090";
       </script>
     <!--<!(endif)-->
 

--- a/static/src/html/iframe.html
+++ b/static/src/html/iframe.html
@@ -73,14 +73,12 @@
 
     <!--(if target dev)><!-->
       <script>
-        jailbreak.env = "LOCAL";
         jailbreak.api_host = "http://localhost:8090";
       </script>
     <!--<!(endif)-->
 
     <!--(if target qa)><!-->
       <script>
-        jailbreak.env = "QA";
         jailbreak.api_host = "https://qa.jbapi.net";
         jailbreak.sentry.enabled = true;
         jailbreak.sentry.dsn = "https://8bc0d346130249dc9952b52c1311e57b@app.getsentry.com/38797";
@@ -99,7 +97,6 @@
 
     <!--(if target prod)><!-->
       <script>
-        jailbreak.env = "PROD";
         jailbreak.api_host = "https://jbapi.net";
         jailbreak.sentry.enabled = true;
         jailbreak.sentry.dsn = "https://38f0e2b9531c4e788601adf26ca4320d@app.getsentry.com/38808";

--- a/static/src/html/index.html
+++ b/static/src/html/index.html
@@ -166,7 +166,6 @@
 
     <!--(if target dev)><!-->
       <script>
-        jailbreak.env = "LOCAL";
         jailbreak.url = "local.jailbreakhq.org"
         jailbreak.api_host = "http://localhost:8090";
         jailbreak.ga_id = "UA-58463386-2";
@@ -175,7 +174,6 @@
 
     <!--(if target qa)><!-->
       <script>
-        jailbreak.env = "QA";
         jailbreak.url = "qa.jailbreakhq.org"
         jailbreak.api_host = "https://qa.jbapi.net";
         jailbreak.ga_id = "UA-58463386-2";
@@ -186,7 +184,6 @@
 
     <!--(if target prod)><!-->
       <script>
-        jailbreak.env = "PROD";
         jailbreak.url = "jailbreakhq.org"
         jailbreak.api_host = "https://jbapi.net";
         jailbreak.ga_id = "UA-58463386-1";

--- a/static/src/scripts/app/AppRouter.coffee
+++ b/static/src/scripts/app/AppRouter.coffee
@@ -93,8 +93,8 @@ define [
       @_showView errorView
 
     _showView: (view) ->
-      if @currentView
-        @currentView?.close()
+      if @currentView?.close
+        @currentView.close()
 
       @currentView = view
 

--- a/static/src/scripts/app/AppRouter.coffee
+++ b/static/src/scripts/app/AppRouter.coffee
@@ -1,16 +1,16 @@
 define [
-  "backbone",
-  "collections/TeamsCollection"
-  "collections/TeamsByCheckinCollection"
-  "models/TeamModel"
-  "views/IndexView"
-  "views/TeamListView"
-  "views/TeamProfileView"
-  "views/DonationFormView"
-  "views/LoginView"
-  "views/admin/MainView"
-  "views/admin/AddFeedView"
-  "views/ErrorView"
+  'backbone',
+  'collections/TeamsCollection'
+  'collections/TeamsByCheckinCollection'
+  'models/TeamModel'
+  'views/IndexView'
+  'views/TeamListView'
+  'views/TeamProfileView'
+  'views/DonationFormView'
+  'views/LoginView'
+  'views/admin/MainView'
+  'views/admin/AddFeedView'
+  'views/ErrorView'
 ], (Backbone, Teams, TeamsByCheckin, Team, IndexView, TeamListView, TeamProfileView, DonationFormView, LoginView, AdminView, AdminFeedView, ErrorView) ->
   class Router extends Backbone.Router
     routes:
@@ -32,11 +32,12 @@ define [
       catch
         # do nothing - user might have blocked tracking scripts
 
+      @bodyContainer = $('#body-container')
       @bind 'route', @_trackPageview
 
     index: ->
       indexView = new IndexView()
-      $("#body-container").html indexView.render().$el
+      @bodyContainer.html indexView.render().$el
       indexView.afterRender()
 
     teams: ->
@@ -44,17 +45,20 @@ define [
       teams.fetch()
       teamsView = new TeamListView
         collection: teams
-      $("#body-container").html teamsView.render().$el
+      @bodyContainer.html teamsView.render().$el
 
     team: (slug) ->
+      team = new Team
+        slug: slug
+      team.fetch()
       teamProfileView = new TeamProfileView
-        teamSlug: slug
-      $("#body-container").html teamProfileView.render().$el
+        model: team
+      @bodyContainer.html teamProfileView.render().$el
 
     donate: ->
       donateView = new DonationFormView
         iphoneRedirect: @_isIphoneRedirect()
-      $("#body-container").html donateView.render().$el
+      @bodyContainer.html donateView.render().$el
 
     donateTeam: (slug) ->
       team = new Team
@@ -65,28 +69,28 @@ define [
             teamId: team.get 'id'
             name: team.get 'names'
             iphoneRedirect: @_isIphoneRedirect()
-          $("#body-container").html donateView.render().$el
+          @bodyContainer.html donateView.render().$el
 
     login: ->
       loginView = new LoginView
-      $("#body-container").html loginView.render().$el
+      @bodyContainer.html loginView.render().$el
 
     admin: ->
       teamsByCheckin = new TeamsByCheckin
       teamsByCheckin.fetch()
       adminView = new AdminView
         teams: teamsByCheckin
-      $("#body-container").html adminView.render().$el
+      @bodyContainer.html adminView.render().$el
 
     adminFeed: ->
       feedView = new AdminFeedView
-      $("#body-container").html feedView.render().$el
+      @bodyContainer.html feedView.render().$el
 
     notFound: ->
       errorView = new ErrorView
         error: 404
 
-      $("#body-container").html errorView.render().$el
+      @bodyContainer.html errorView.render().$el
 
     _isIphoneRedirect: ->
       url = Backbone.history.getFragment()
@@ -96,6 +100,6 @@ define [
       try
         require ['//www.google-analytics.com/analytics.js'], (data) ->
           url = Backbone.history.getFragment()
-          window.ga 'send', 'pageview', "/#{url}"
+          window.ga 'send', 'pageview', '/#{url}'
       catch
         # do nothing - user might have blocked tracking scripts

--- a/static/src/scripts/app/AppRouter.coffee
+++ b/static/src/scripts/app/AppRouter.coffee
@@ -36,16 +36,16 @@ define [
       @bind 'route', @_trackPageview
 
     index: ->
-      indexView = new IndexView()
+      indexView = new IndexView
       @bodyContainer.html indexView.render().$el
-      indexView.afterRender()
+      @_showView indexView
 
     teams: ->
-      teams = new Teams()
+      teams = new Teams
       teams.fetch()
       teamsView = new TeamListView
         collection: teams
-      @bodyContainer.html teamsView.render().$el
+      @_showView teamsView
 
     team: (slug) ->
       team = new Team
@@ -53,12 +53,12 @@ define [
       team.fetch()
       teamProfileView = new TeamProfileView
         model: team
-      @bodyContainer.html teamProfileView.render().$el
+      @_showView teamProfileView
 
     donate: ->
       donateView = new DonationFormView
         iphoneRedirect: @_isIphoneRedirect()
-      @bodyContainer.html donateView.render().$el
+      @_showView donateView
 
     donateTeam: (slug) ->
       team = new Team
@@ -69,28 +69,36 @@ define [
             teamId: team.get 'id'
             name: team.get 'names'
             iphoneRedirect: @_isIphoneRedirect()
-          @bodyContainer.html donateView.render().$el
+          @_showView DonationFormView
 
     login: ->
       loginView = new LoginView
-      @bodyContainer.html loginView.render().$el
+      @_showView loginView
 
     admin: ->
       teamsByCheckin = new TeamsByCheckin
       teamsByCheckin.fetch()
       adminView = new AdminView
         teams: teamsByCheckin
-      @bodyContainer.html adminView.render().$el
+      @_showView adminView
 
     adminFeed: ->
       feedView = new AdminFeedView
-      @bodyContainer.html feedView.render().$el
+      @_showView feedView
 
     notFound: ->
       errorView = new ErrorView
         error: 404
 
-      @bodyContainer.html errorView.render().$el
+      @_showView errorView
+
+    _showView: (view) ->
+      if @currentView
+        @currentView?.close()
+
+      @currentView = view
+
+      @bodyContainer.html view.render().$el
 
     _isIphoneRedirect: ->
       url = Backbone.history.getFragment()

--- a/static/src/scripts/app/AppRouter.coffee
+++ b/static/src/scripts/app/AppRouter.coffee
@@ -4,14 +4,14 @@ define [
   'collections/TeamsByCheckinCollection'
   'models/TeamModel'
   'views/IndexView'
-  'views/TeamListView'
+  'views/TeamsListView'
   'views/TeamProfileView'
   'views/DonationFormView'
   'views/LoginView'
   'views/admin/MainView'
   'views/admin/AddFeedView'
   'views/ErrorView'
-], (Backbone, Teams, TeamsByCheckin, Team, IndexView, TeamListView, TeamProfileView, DonationFormView, LoginView, AdminView, AdminFeedView, ErrorView) ->
+], (Backbone, Teams, TeamsByCheckin, Team, IndexView, TeamsListView, TeamProfileView, DonationFormView, LoginView, AdminView, AdminFeedView, ErrorView) ->
   class Router extends Backbone.Router
     routes:
       '':                   'index'
@@ -37,13 +37,12 @@ define [
 
     index: ->
       indexView = new IndexView
-      @bodyContainer.html indexView.render().$el
       @_showView indexView
 
     teams: ->
       teams = new Teams
       teams.fetch()
-      teamsView = new TeamListView
+      teamsView = new TeamsListView
         collection: teams
       @_showView teamsView
 

--- a/static/src/scripts/app/AppRouter.coffee
+++ b/static/src/scripts/app/AppRouter.coffee
@@ -27,7 +27,7 @@ define [
     initialize: ->
       try
         require ['//www.google-analytics.com/analytics.js'], (data) ->
-          window.ga 'create', jailbreak.ga_id
+          window?.ga 'create', jailbreak.ga_id
           return
       catch
         # do nothing - user might have blocked tracking scripts
@@ -100,6 +100,6 @@ define [
       try
         require ['//www.google-analytics.com/analytics.js'], (data) ->
           url = Backbone.history.getFragment()
-          window.ga 'send', 'pageview', '/#{url}'
+          window?.ga 'send', 'pageview', '/#{url}'
       catch
         # do nothing - user might have blocked tracking scripts

--- a/static/src/scripts/app/AppRouter.coffee
+++ b/static/src/scripts/app/AppRouter.coffee
@@ -68,7 +68,7 @@ define [
             teamId: team.get 'id'
             name: team.get 'names'
             iphoneRedirect: @_isIphoneRedirect()
-          @_showView DonationFormView
+          @_showView donateView
 
     login: ->
       loginView = new LoginView

--- a/static/src/scripts/app/collections/CheckinsCollection.coffee
+++ b/static/src/scripts/app/collections/CheckinsCollection.coffee
@@ -12,5 +12,7 @@ define [
     initialize: (data, options) =>
       @teamId = options.teamId
 
+      super
+
     url: =>
       super + "/teams/#{@teamId}/checkins?limit=20"

--- a/static/src/scripts/app/collections/CheckinsCollection.coffee
+++ b/static/src/scripts/app/collections/CheckinsCollection.coffee
@@ -1,10 +1,10 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/BaseCollectionMixen"
-  "models/CheckinModel"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/BaseCollectionMixen'
+  'models/CheckinModel'
 ], ($, _, Backbone, Mixen, BaseCollectionMixen, Checkin) ->
   class Checkins extends Mixen(BaseCollectionMixen)
     model: Checkin
@@ -13,4 +13,4 @@ define [
       @teamId = options.teamId
 
     url: =>
-      super + "/teams/" + @teamId + "/checkins?limit=20"
+      super + "/teams/#{@teamId}/checkins?limit=20"

--- a/static/src/scripts/app/collections/DonationsCollection.coffee
+++ b/static/src/scripts/app/collections/DonationsCollection.coffee
@@ -1,11 +1,11 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/FilterableCollectionMixen"
-  "mixens/BaseCollectionMixen"
-  "models/DonationModel"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/FilterableCollectionMixen'
+  'mixens/BaseCollectionMixen'
+  'models/DonationModel'
 ], ($, _, Backbone, Mixen, FilterableCollectionMixen, BaseCollectionMixen, Donation) ->
   class Donations extends Mixen(FilterableCollectionMixen, BaseCollectionMixen)
     model: Donation
@@ -13,8 +13,8 @@ define [
     url: =>
       if @filters
         encodedFilters = encodeURIComponent JSON.stringify @filters
-        url = "/donations?filters=" + encodedFilters
+        url = "/donations?filters=#{encodedFilters}"
       else
-        url = "/donations"
+        url = '/donations'
 
       super + url

--- a/static/src/scripts/app/collections/DonationsCollection.coffee
+++ b/static/src/scripts/app/collections/DonationsCollection.coffee
@@ -4,10 +4,11 @@ define [
   'backbone'
   'mixen'
   'mixens/FilterableCollectionMixen'
+  'mixens/TotalCountCollectionMixen'
   'mixens/BaseCollectionMixen'
   'models/DonationModel'
-], ($, _, Backbone, Mixen, FilterableCollectionMixen, BaseCollectionMixen, Donation) ->
-  class Donations extends Mixen(FilterableCollectionMixen, BaseCollectionMixen)
+], ($, _, Backbone, Mixen, FilterableCollection, TotalCountCollection, BaseCollection, Donation) ->
+  class Donations extends Mixen(FilterableCollection, TotalCountCollection, BaseCollection)
     model: Donation
 
     url: =>

--- a/static/src/scripts/app/collections/EventsCollection.coffee
+++ b/static/src/scripts/app/collections/EventsCollection.coffee
@@ -1,11 +1,11 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/FilterableCollectionMixen"
-  "mixens/BaseCollectionMixen"
-  "models/feed/EventModel"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/FilterableCollectionMixen'
+  'mixens/BaseCollectionMixen'
+  'models/feed/EventModel'
 ], ($, _, Backbone, Mixen, FilterableCollectionMixen, BaseCollectionMixen, Event) ->
   class Events extends Mixen(FilterableCollectionMixen, BaseCollectionMixen)
     model: Event
@@ -16,7 +16,7 @@ define [
     url: =>
       if @filters
         filtersJSON = encodeURIComponent JSON.stringify @filters
-        url = "/events?limit=40&filters=" + filtersJSON
+        url = "/events?limit=40&filters=#{filtersJSON}"
       else
-        url = "/events?limit=40"
+        url = '/events?limit=40'
       super + url

--- a/static/src/scripts/app/collections/EventsCollection.coffee
+++ b/static/src/scripts/app/collections/EventsCollection.coffee
@@ -6,17 +6,14 @@ define [
   'mixens/FilterableCollectionMixen'
   'mixens/BaseCollectionMixen'
   'models/feed/EventModel'
-], ($, _, Backbone, Mixen, FilterableCollectionMixen, BaseCollectionMixen, Event) ->
-  class Events extends Mixen(FilterableCollectionMixen, BaseCollectionMixen)
+], ($, _, Backbone, Mixen, FilterableCollection, BaseCollection, Event) ->
+  class Events extends Mixen(FilterableCollection, BaseCollection)
     model: Event
-
-    initialize: (data, options) ->
-      super
 
     url: =>
       if @filters
         filtersJSON = encodeURIComponent JSON.stringify @filters
-        url = "/events?limit=20&filters=#{filtersJSON}"
+        url = "/events?limit=15&filters=#{filtersJSON}"
       else
-        url = '/events?limit=20'
+        url = '/events?limit=15'
       super + url

--- a/static/src/scripts/app/collections/EventsCollection.coffee
+++ b/static/src/scripts/app/collections/EventsCollection.coffee
@@ -16,7 +16,7 @@ define [
     url: =>
       if @filters
         filtersJSON = encodeURIComponent JSON.stringify @filters
-        url = "/events?limit=40&filters=#{filtersJSON}"
+        url = "/events?limit=20&filters=#{filtersJSON}"
       else
-        url = '/events?limit=40'
+        url = '/events?limit=20'
       super + url

--- a/static/src/scripts/app/collections/TeamsByCheckinCollection.coffee
+++ b/static/src/scripts/app/collections/TeamsByCheckinCollection.coffee
@@ -1,17 +1,17 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/FilterableCollectionMixen"
-  "mixens/BaseCollectionMixen"
-  "models/TeamModel"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/FilterableCollectionMixen'
+  'mixens/BaseCollectionMixen'
+  'models/TeamModel'
 ], ($, _, Backbone, Mixen, FilterableCollectionMixen, BaseCollectionMixen, Team) ->
   class TeamsByCheckin extends Mixen(FilterableCollectionMixen, BaseCollectionMixen)
     model: Team
 
     url: ->
-      url = "/teams/lastcheckin"
+      url = '/teams/lastcheckin'
 
       super + url
 

--- a/static/src/scripts/app/collections/TeamsCollection.coffee
+++ b/static/src/scripts/app/collections/TeamsCollection.coffee
@@ -1,11 +1,11 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/FilterableCollectionMixen"
-  "mixens/BaseCollectionMixen"
-  "models/TeamModel"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/FilterableCollectionMixen'
+  'mixens/BaseCollectionMixen'
+  'models/TeamModel'
 ], ($, _, Backbone, Mixen, FilterableCollectionMixen, BaseCollectionMixen, Team) ->
   class Teams extends Mixen(FilterableCollectionMixen, BaseCollectionMixen)
     model: Team
@@ -13,9 +13,9 @@ define [
     url: =>
       if @filters
         encodedFilters = encodeURIComponent JSON.stringify @filters
-        url = "/teams?filters=" + encodedFilters
+        url = '/teams?filters=' + encodedFilters
       else
-        url = "/teams"
+        url = '/teams'
 
       super + url
 

--- a/static/src/scripts/app/collections/UsersCollection.coffee
+++ b/static/src/scripts/app/collections/UsersCollection.coffee
@@ -9,9 +9,6 @@ define [
   class Users extends Mixen(BaseCollectionMixen)
     model: User
 
-    initialize: (options) ->
-      super
-
     url: =>
       url = '/users'
       super + url

--- a/static/src/scripts/app/collections/UsersCollection.coffee
+++ b/static/src/scripts/app/collections/UsersCollection.coffee
@@ -1,10 +1,10 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/BaseCollectionMixen"
-  "models/UserModel"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/BaseCollectionMixen'
+  'models/UserModel'
 ], ($, _, Backbone, Mixen, BaseCollectionMixen, User) ->
   class Users extends Mixen(BaseCollectionMixen)
     model: User
@@ -13,5 +13,5 @@ define [
       super
 
     url: =>
-      url = "/users"
+      url = '/users'
       super + url

--- a/static/src/scripts/app/iframe.coffee
+++ b/static/src/scripts/app/iframe.coffee
@@ -1,16 +1,16 @@
 require [
-  "jquery"
-  "underscore"
-  "foundation"
-  "foundation.topbar"
-  "raven"
-  "collections/TeamsCollection"
-  "models/JailbreakModel"
-  "views/TeamsMapView"
-  "views/TopTeamsCardListView"
-  "moment"
-  "signet"
-  "async"
+  'jquery'
+  'underscore'
+  'foundation'
+  'foundation.topbar'
+  'raven'
+  'collections/TeamsCollection'
+  'models/JailbreakModel'
+  'views/TeamsMapView'
+  'views/TopTeamsCardListView'
+  'moment'
+  'signet'
+  'async'
 ], ($, _, foundation, topbar, Raven, Teams, Jailbreak, TeamsMapView, TopTeamsCardListiew, moment) ->
   
   $ ->
@@ -37,5 +37,5 @@ require [
     topTeamsCardsView = new TopTeamsCardListiew
       collection: @teams
 
-    require ["async!//maps.googleapis.com/maps/api/js?v=3.exp&sensor=false"], (data) =>
+    require ['async!//maps.googleapis.com/maps/api/js?v=3.exp&sensor=false'], (data) =>
       @teamsMapView.googleMapsLoaded()

--- a/static/src/scripts/app/iframe.coffee
+++ b/static/src/scripts/app/iframe.coffee
@@ -36,6 +36,7 @@ require [
 
     topTeamsCardsView = new TopTeamsCardListiew
       collection: @teams
+    topTeamsCardsView.render()
 
     require ['async!//maps.googleapis.com/maps/api/js?v=3.exp&sensor=false'], (data) =>
       @teamsMapView.googleMapsLoaded()

--- a/static/src/scripts/app/main.coffee
+++ b/static/src/scripts/app/main.coffee
@@ -1,14 +1,14 @@
 require [
-  "jquery"
-  "underscore"
-  "backbone"
-  "foundation"
-  "foundation.topbar"
-  "raven"
-  "AppRouter"
-  "messenger"
-  "signet"
-  "async"
+  'jquery'
+  'underscore'
+  'backbone'
+  'foundation'
+  'foundation.topbar'
+  'raven'
+  'AppRouter'
+  'messenger'
+  'signet'
+  'async'
 ], ($, _, Backbone, foundation, topbar, Raven, Router, Messenger) ->
   
   $ ->
@@ -25,26 +25,26 @@ require [
     AppRouter = new Router()
 
     # Clean up after any previous runs
-    window.location.hash = ""
+    window.location.hash = ''
     Backbone.history.stop()
 
     Backbone.history.start
       pushState: true
 
     Messenger.options =
-      theme: "flat"
+      theme: 'flat'
 
     # hook all links on the page
-    $(document).on "click", "a[href^='/']", (event) ->
+    $(document).on 'click', "a[href^='/']", (event) ->
 
-      href = $(event.currentTarget).attr("href")
+      href = $(event.currentTarget).attr 'href'
 
       # Allow shift+click for new tabs, etc.
       if !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey
         event.preventDefault()
 
         # Remove leading slashes and hash bangs (backward compatablility)
-        url = href.replace(/^\//, "").replace("\#\!\/", "")
+        url = href.replace(/^\//, '').replace("\#\!\/", '')
 
         # Instruct Backbone to trigger routing events
         AppRouter.navigate url, { trigger: true }

--- a/static/src/scripts/app/mixens/AuthMixen.coffee
+++ b/static/src/scripts/app/mixens/AuthMixen.coffee
@@ -23,11 +23,9 @@ define [
   class Auth
     loaded: false
 
-    initialize: (data, options) ->
+    constructor: ->
       @.on 'error', (collection, resp, options) ->
         if resp.status == 401 or resp.status == 419
           # unauthorized or authentication token expired
           Backbone.history.navigate 'login', true
           localStorage.removeItem 'apiToken'
-
-      super

--- a/static/src/scripts/app/mixens/AuthMixen.coffee
+++ b/static/src/scripts/app/mixens/AuthMixen.coffee
@@ -1,18 +1,18 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
 ], ($, _, backbone, Mixen) ->
   backboneSync = Backbone.sync
 
   Backbone.sync = (method, model, options) ->
-    if localStorage.getItem("apiToken") != null
-      apiToken = JSON.parse(localStorage.getItem "apiToken")
-      token = apiToken.userId + ':' + apiToken.apiToken
+    if localStorage.getItem 'apiToken' != null
+      apiToken = JSON.parse localStorage.getItem 'apiToken'
+      token = "#{apiToken.userId}:#{apiToken.apiToken}"
       tokenB64 = btoa(token)
       authHeaders =
-        "Authorization": "Basic " + tokenB64
+        'Authorization': "Basic #{tokenB64}"
 
       # ensure we don't overwrite any headers in options by merging our Auth headers in
       options.headers = options.headers or {}
@@ -24,10 +24,10 @@ define [
     loaded: false
 
     initialize: (data, options) ->
-      @.on "error", (collection, resp, options) ->
+      @.on 'error', (collection, resp, options) ->
         if resp.status == 401 or resp.status == 419
           # unauthorized or authentication token expired
-          Backbone.history.navigate "login", true
-          localStorage.removeItem("apiToken")
+          Backbone.history.navigate 'login', true
+          localStorage.removeItem 'apiToken'
 
       super

--- a/static/src/scripts/app/mixens/BaseCollectionMixen.coffee
+++ b/static/src/scripts/app/mixens/BaseCollectionMixen.coffee
@@ -8,16 +8,7 @@ define [
 ], ($, _, backbone, Mixen, AuthMixen, LoadedMixen) ->
   class BaseCollection extends Mixen(LoadedMixen, AuthMixen, Backbone.Collection)
     urlRoot: jailbreak.api_host
-    totalCount: null
 
     url: ->
       super
       jailbreak.api_host
-
-    parse: (resp, options) ->
-      super
-      # parse out the total count header
-      total = options.xhr.getResponseHeader 'X-Total-Count'
-      if total
-        @totalCount = total
-      resp

--- a/static/src/scripts/app/mixens/BaseCollectionMixen.coffee
+++ b/static/src/scripts/app/mixens/BaseCollectionMixen.coffee
@@ -10,9 +10,6 @@ define [
     urlRoot: jailbreak.api_host
     totalCount: null
 
-    initialize: (data, options) ->
-      super # necessary to not break chain
-
     url: ->
       super
       jailbreak.api_host

--- a/static/src/scripts/app/mixens/BaseCollectionMixen.coffee
+++ b/static/src/scripts/app/mixens/BaseCollectionMixen.coffee
@@ -1,16 +1,16 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/AuthMixen"
-  "mixens/LoadedMixen"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/AuthMixen'
+  'mixens/LoadedMixen'
 ], ($, _, backbone, Mixen, AuthMixen, LoadedMixen) ->
   class BaseCollection extends Mixen(LoadedMixen, AuthMixen, Backbone.Collection)
     urlRoot: jailbreak.api_host
     totalCount: null
 
-    initialize: ->
+    initialize: (data, options) ->
       super # necessary to not break chain
 
     url: ->
@@ -20,7 +20,7 @@ define [
     parse: (resp, options) ->
       super
       # parse out the total count header
-      total = options.xhr.getResponseHeader("X-Total-Count")
+      total = options.xhr.getResponseHeader 'X-Total-Count'
       if total
         @totalCount = total
       resp

--- a/static/src/scripts/app/mixens/BaseModelMixen.coffee
+++ b/static/src/scripts/app/mixens/BaseModelMixen.coffee
@@ -1,13 +1,24 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/AuthMixen"
-  "mixens/LoadedMixen"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/AuthMixen'
+  'mixens/LoadedMixen'
 ], ($, _, backbone, Mixen, AuthMixen, LoadedMixen) ->
   class BaseModel extends Mixen(LoadedMixen, AuthMixen, Backbone.Model)
     urlRoot: jailbreak.api_host
 
     initialize: ->
       super # necessary to not break chain
+
+    getRenderContext: ->
+      context = super ? {}
+
+      data =
+        error: @error
+        errorMessage: @errorMessage
+        errorStatus: @errorStatus
+        loaded: @loaded
+
+      _.extend context, data

--- a/static/src/scripts/app/mixens/BaseModelMixen.coffee
+++ b/static/src/scripts/app/mixens/BaseModelMixen.coffee
@@ -9,9 +9,6 @@ define [
   class BaseModel extends Mixen(LoadedMixen, AuthMixen, Backbone.Model)
     urlRoot: jailbreak.api_host
 
-    initialize: ->
-      super # necessary to not break chain
-
     getRenderContext: ->
       context = super ? {}
 

--- a/static/src/scripts/app/mixens/BaseViewMixen.coffee
+++ b/static/src/scripts/app/mixens/BaseViewMixen.coffee
@@ -1,0 +1,9 @@
+define [
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/EventJanitorMixen'
+], ($, _, backbone, Mixen, EventJanitorMixen) ->
+  class BaseView extends Mixen(EventJanitorMixen, Backbone.View)
+    # spooky for now

--- a/static/src/scripts/app/mixens/CollectionViewMixen.coffee
+++ b/static/src/scripts/app/mixens/CollectionViewMixen.coffee
@@ -7,9 +7,9 @@ define [
       if not options.collection
         new Error 'This view needs a collection in the initialize options'
       @collection = options.collection
-      @listenTo @collection, 'sync error', @render
-
-      super
+      @listenTo @collection, 'sync error', =>
+        @render()
+        @renderCollection?()
 
     getRenderContext: ->
       context = super ? {}

--- a/static/src/scripts/app/mixens/CollectionViewMixen.coffee
+++ b/static/src/scripts/app/mixens/CollectionViewMixen.coffee
@@ -1,0 +1,23 @@
+define [
+  'underscore'
+], (_) ->
+  class CollectionView
+
+    initialize: (options) ->
+      if not options.collection
+        new Error 'This view needs a collection in the initialize options'
+      @collection = options.collection
+      @listenTo @collection, 'sync error', @render
+
+      super
+
+    getRenderContext: ->
+      context = super ? {}
+
+      data =
+        error: @collection.error
+        errorMessage: @collection.errorMessage
+        errorStatus: @collection.errorStatus
+        loaded: @collection.loaded
+
+      _.extend context, data

--- a/static/src/scripts/app/mixens/EventJanitor.coffee
+++ b/static/src/scripts/app/mixens/EventJanitor.coffee
@@ -1,0 +1,15 @@
+define [
+  'underscore'
+], (_) ->
+  class EventJanitor
+    rememberView: (view) ->
+      @views ?= []
+      @views.push view
+      view
+
+    undelegateEvents: ->
+      @stopListening()
+
+      if @views?
+        for view in @views
+          view.stopListening()

--- a/static/src/scripts/app/mixens/EventJanitorMixen.coffee
+++ b/static/src/scripts/app/mixens/EventJanitorMixen.coffee
@@ -7,9 +7,12 @@ define [
       @views.push view
       view
 
-    undelegateEvents: ->
+    close: ->
       @stopListening()
 
       if @views?
         for view in @views
           view.stopListening()
+          view.remove()
+
+      @remove()

--- a/static/src/scripts/app/mixens/EventJanitorMixen.coffee
+++ b/static/src/scripts/app/mixens/EventJanitorMixen.coffee
@@ -14,8 +14,5 @@ define [
         for view in @views
           if view?.close
             view.close()
-          else
-            view.stopListening()
-            view.remove()
 
       @remove()

--- a/static/src/scripts/app/mixens/EventJanitorMixen.coffee
+++ b/static/src/scripts/app/mixens/EventJanitorMixen.coffee
@@ -12,7 +12,10 @@ define [
 
       if @views?
         for view in @views
-          view.stopListening()
-          view.remove()
+          if view?.close
+            view.close()
+          else
+            view.stopListening()
+            view.remove()
 
       @remove()

--- a/static/src/scripts/app/mixens/FilterableCollectionMixen.coffee
+++ b/static/src/scripts/app/mixens/FilterableCollectionMixen.coffee
@@ -1,7 +1,6 @@
 define [
-  "jquery"
-  "underscore"
-], ($, _) ->
+  'underscore'
+], (_) ->
   class FilterableCollection
     filters: null
 

--- a/static/src/scripts/app/mixens/FilterableCollectionMixen.coffee
+++ b/static/src/scripts/app/mixens/FilterableCollectionMixen.coffee
@@ -4,8 +4,6 @@ define [
   class FilterableCollection
     filters: null
 
-    initialize: (data, options) ->
+    constructor: (data, options) ->
       if options
         @filters = options.filters
-
-      super

--- a/static/src/scripts/app/mixens/LoadedMixen.coffee
+++ b/static/src/scripts/app/mixens/LoadedMixen.coffee
@@ -6,7 +6,7 @@ define [
     loaded: false
     error: false
 
-    initialize: (data, options) ->
+    constructor: (data, options) ->
       @.on 'sync', =>
         @loaded = true
         @trigger 'loaded'
@@ -14,8 +14,6 @@ define [
 
       @.on 'error', (model, error) =>
         @error = true
-        @errorMessage = error.responseJSON.message
+        @errorMessage = error.responseJSON?.message
         @errorStatus = error.status
       , @
-
-      super

--- a/static/src/scripts/app/mixens/LoadedMixen.coffee
+++ b/static/src/scripts/app/mixens/LoadedMixen.coffee
@@ -1,12 +1,21 @@
 define [
-  "jquery"
-], ($) ->
+  'jquery'
+  'underscore'
+], ($, _) ->
   class Loaded
     loaded: false
+    error: false
 
     initialize: (data, options) ->
-      @.on "sync", =>
+      @.on 'sync', =>
         @loaded = true
+        @trigger 'loaded'
+      , @
+
+      @.on 'error', (model, error) =>
+        @error = true
+        @errorMessage = error.responseJSON.message
+        @errorStatus = error.status
       , @
 
       super

--- a/static/src/scripts/app/mixens/RenderOnlyWithModelMixen.coffee
+++ b/static/src/scripts/app/mixens/RenderOnlyWithModelMixen.coffee
@@ -1,7 +1,0 @@
-define [
-],  ->
-  class RenderOnlyWithModel
-    render: ->
-      return unless @model
-
-      super

--- a/static/src/scripts/app/mixens/RequiresLoginMixen.coffee
+++ b/static/src/scripts/app/mixens/RequiresLoginMixen.coffee
@@ -1,13 +1,17 @@
 define [
-  "backbone"
-], (Backbone) ->
+  'backbone'
+  'moment'
+], (Backbone, moment) ->
   class RequireLogin
 
     render: ->
-      if localStorage.getItem("apiToken") == null
+      tokenJSON = localStorage.getItem 'apiToken'
+      token = JSON.parse tokenJSON
+
+      if tokenJSON == null or (token.expires < moment().utc().unix())
         # if no token should to login
         # another check elsewhere will see if the token
         # is valid
-        window.location =  "//" + jailbreak.url + "/login"
+        window.location =  "//#{jailbreak.url}/login"
 
       super

--- a/static/src/scripts/app/mixens/TotalCountCollectionMixen.coffee
+++ b/static/src/scripts/app/mixens/TotalCountCollectionMixen.coffee
@@ -1,0 +1,15 @@
+define [
+  'jquery'
+  'underscore'
+  'backbone'
+], ($, _, backbone, Mixen, AuthMixen, LoadedMixen) ->
+  class TotalCountCollection
+    totalCount: null
+
+    parse: (resp, options) ->
+      super
+      # parse out the total count header
+      total = options.xhr.getResponseHeader 'X-Total-Count'
+      if total
+        @totalCount = total
+      resp

--- a/static/src/scripts/app/models/CheckinModel.coffee
+++ b/static/src/scripts/app/models/CheckinModel.coffee
@@ -1,9 +1,9 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/BaseModelMixen"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/BaseModelMixen'
 ], ($, _, Backbone, Mixen, BaseModelMixen) ->
   class Checkin extends Mixen(BaseModelMixen)
 
@@ -13,7 +13,7 @@ define [
       super
 
     url: ->
-      jailbreak.api_host + "/teams/" + @teamId + "/checkins"
+      jailbreak.api_host + '/teams/' + @teamId + '/checkins'
 
     getRenderContext: ->
       @.toJSON()

--- a/static/src/scripts/app/models/DonationModel.coffee
+++ b/static/src/scripts/app/models/DonationModel.coffee
@@ -1,12 +1,12 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "models/TeamModel"
-  "mixens/BaseModelMixen"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'models/TeamModel'
+  'mixens/BaseModelMixen'
 ], ($, _, Backbone, Mixen, Team, BaseModelMixen) ->
-  class Checkin extends Mixen(BaseModelMixen)
+  class Donation extends Mixen(BaseModelMixen)
     
     initialize: (options) ->
       super
@@ -19,8 +19,8 @@ define [
       response
 
     getRenderContext: =>
-      donation = @.toJSON()
-      if @.has('team')
-        donation.team = @.get('team').toJSON()
+      context = @toJSON()
+      if @.has 'team'
+        context.team = @.get('team').toJSON()
 
-      donation
+      context

--- a/static/src/scripts/app/models/JailbreakModel.coffee
+++ b/static/src/scripts/app/models/JailbreakModel.coffee
@@ -1,12 +1,12 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/BaseModelMixen"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/BaseModelMixen'
 ], ($, _, Backbone, Mixen, BaseModelMixen) ->
   class Jailbreak extends Mixen(BaseModelMixen)
-    urlRoot: jailbreak.api_host + "/"
+    urlRoot: jailbreak.api_host + '/'
     defaults:
       amountRaised: 0
 

--- a/static/src/scripts/app/models/PositionModel.coffee
+++ b/static/src/scripts/app/models/PositionModel.coffee
@@ -1,7 +1,7 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
+  'jquery'
+  'underscore'
+  'backbone'
 ], ($, _, Backbone) ->
   class Position extends Backbone.Model
     defaults:

--- a/static/src/scripts/app/models/TeamModel.coffee
+++ b/static/src/scripts/app/models/TeamModel.coffee
@@ -1,26 +1,23 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/BaseModelMixen"
-  "models/CheckinModel"
-], ($, _, Backbone, Mixen, Checkin, BaseModelMixen) ->
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/BaseModelMixen'
+  'models/CheckinModel'
+], ($, _, Backbone, Mixen, BaseModelMixen, Checkin) ->
   class Team extends Mixen(BaseModelMixen)
     defaults:
-      avatar: "https://static.jailbreakhq.org/avatars/jb-default-avatar.jpg"
+      avatar: 'https://static.jailbreakhq.org/avatars/jb-default-avatar.jpg'
 
-    initialize: (options) =>
-      if options.slug
-        @slug = options.slug
-
+    initialize: (options) ->
       super
 
     url: =>
-      if @slug
-        jailbreak.api_host + "/teams/slug/" + @slug
+      if @get 'slug'
+        jailbreak.api_host + '/teams/slug/' + @get 'slug'
       else
-        jailbreak.api_host + "/teams/" + @.get("id")
+        jailbreak.api_host + '/teams/' + @get 'id'
 
     parse: (response) ->
       lastCheckin = response.lastCheckin
@@ -29,9 +26,11 @@ define [
 
       response
 
-    getRenderContext: =>
-      team = @.toJSON()
-      if @.has('lastCheckin')
-        team.lastCheckin = @.get('lastCheckin').toJSON()
+    getRenderContext: ->
+      context = super ? {}
 
-      team
+      context = _.extend context, @.toJSON()
+      if @.has 'lastCheckin'
+        context.lastCheckin = @.get('lastCheckin').toJSON()
+
+      context

--- a/static/src/scripts/app/models/UserModel.coffee
+++ b/static/src/scripts/app/models/UserModel.coffee
@@ -1,9 +1,9 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "mixen"
-  "mixens/BaseModelMixen"
+  'jquery'
+  'underscore'
+  'backbone'
+  'mixen'
+  'mixens/BaseModelMixen'
 ], ($, _, Backbone, Mixen, BaseModelMixen) ->
   class User extends Mixen(BaseModelMixen)
     # spooky

--- a/static/src/scripts/app/views/DonationFormView.coffee
+++ b/static/src/scripts/app/views/DonationFormView.coffee
@@ -1,14 +1,14 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "ladda"
-  "foundation"
-  "foundation.alert"
-  "foundation.tooltip"
-  "jquery.payment"
-  "animo"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'ladda'
+  'foundation'
+  'foundation.alert'
+  'foundation.tooltip'
+  'jquery.payment'
+  'animo'
 ], ($, _, Backbone, jade, Ladda, foundation) ->
   class DonationFormView extends Backbone.View
     template: jade.donationForm
@@ -16,7 +16,7 @@ define [
       'click #donate-submit': 'donateSubmissionHandler'
 
     initialize: (options) =>
-      @name = options?.name or "JailbreakHQ"
+      @name = options?.name or 'JailbreakHQ'
       @teamId = options?.teamId or 0
       @parentView = options?.parent
       @iphoneRedirect = options?.iphoneRedirect or false
@@ -28,23 +28,23 @@ define [
 
       @$el.html @template data
 
-      $(@$el).foundation("tooltip", "reflow")
+      $(@$el).foundation('tooltip', 'reflow')
 
       # add stripe's jquery.payment input field restrictions (super cool)
-      $(".cc-num", @$el).payment("formatCardNumber")
-      $(".cc-exp", @$el).payment("formatCardExpiry")
-      $(".cc-cvc", @$el).payment("formatCardCVC")
-      $("[data-numeric]", @$el).payment("restrictNumeric")
+      $('.cc-num', @$el).payment('formatCardNumber')
+      $('.cc-exp', @$el).payment('formatCardExpiry')
+      $('.cc-cvc', @$el).payment('formatCardCVC')
+      $('[data-numeric]', @$el).payment('restrictNumeric')
 
       @
 
     donateFormResponse: (type, messages) =>
-      $("#stripe-responses").html jade.alert {type: type, messages: messages}
-      $(@$el).foundation("alert", "reflow")
+      $('#stripe-responses').html jade.alert {type: type, messages: messages}
+      $(@$el).foundation('alert', 'reflow')
       @l?.stop()
 
     clearDonateFormResponse: ->
-      $("#stripe-responses").empty()
+      $('#stripe-responses').empty()
 
     validateEmail: (email) ->
       re = /\S+@\S+\.\S+/
@@ -53,64 +53,64 @@ define [
     donateSubmissionHandler: (event) =>
       # prevent action and disable button
       event.preventDefault()
-      @l = Ladda.create document.querySelector "#donate-submit"
+      @l = Ladda.create document.querySelector '#donate-submit'
       @l.start()
 
       # extract form fields
-      number = $(".cc-num", @$el).val()
-      exp = $(".cc-exp", @$el).val()
-      cvc = parseInt $(".cc-cvc", @$el).val().trim()
-      amount = parseInt $(".cc-amount", @$el).val()
-      name = $(".cc-name", @$el).val()
-      email = $(".cc-email", @$el).val()
+      number = $('.cc-num', @$el).val()
+      exp = $('.cc-exp', @$el).val()
+      cvc = parseInt $('.cc-cvc', @$el).val().trim()
+      amount = parseInt $('.cc-amount', @$el).val()
+      name = $('.cc-name', @$el).val()
+      email = $('.cc-email', @$el).val()
 
-      exp_month = parseInt exp.split("/")[0]?.trim()
-      exp_year = parseInt exp.split("/")[1]?.trim()
+      exp_month = parseInt exp.split('/')[0]?.trim()
+      exp_year = parseInt exp.split('/')[1]?.trim()
 
       # do some form validation
       errors = []
 
       valid = true
       if not @validateEmail email
-        errors.push("Please provide an email address")
-        $(".cc-email", @$el).addClass("error-field")
+        errors.push('Please provide an email address')
+        $('.cc-email', @$el).addClass('error-field')
         valid = false
       else
-        $(".cc-email", @$el).removeClass("error-field")
+        $('.cc-email', @$el).removeClass('error-field')
 
       if not $.payment.validateCardNumber(number)
-        errors.push("Check your card number")
-        $(".cc-num", @$el).addClass("error-field")
+        errors.push('Check your card number')
+        $('.cc-num', @$el).addClass('error-field')
         valid = false
       else
-        $(".cc-num", @$el).removeClass("error-field")
+        $('.cc-num', @$el).removeClass('error-field')
 
       if not $.payment.validateCardExpiry(exp_month, exp_year)
-        errors.push("Check your card expiry")
-        $(".cc-exp", @$el).addClass("error-field")
+        errors.push('Check your card expiry')
+        $('.cc-exp', @$el).addClass('error-field')
         valid = false
       else
-        $(".cc-exp", @$el).removeClass("error-field")
+        $('.cc-exp', @$el).removeClass('error-field')
 
       if not $.payment.validateCardCVC(cvc)
-        errors.push("Check the CVC number is on the back of your card")
-        $(".cc-cvc", @$el).addClass("error-field")
+        errors.push('Check the CVC number is on the back of your card')
+        $('.cc-cvc', @$el).addClass('error-field')
         valid = false
       else
-        $(".cc-cvc", @$el).removeClass("error-field")
+        $('.cc-cvc', @$el).removeClass('error-field')
 
       if not (amount >= 5)
-        errors.push("Minimum donation 5 euro")
-        $(".cc-amount", @$el).addClass("error-field")
+        errors.push('Minimum donation 5 euro')
+        $('.cc-amount', @$el).addClass('error-field')
         valid = false
       else
-        $(".cc-amount", @$el).removeClass("error-field")
+        $('.cc-amount', @$el).removeClass('error-field')
 
 
       if not valid
-        @donateFormResponse("alert", errors)
-        $("#donate-form .content").animo
-          animation: "shake-subtle"
+        @donateFormResponse('alert', errors)
+        $('#donate-form .content').animo
+          animation: 'shake-subtle'
           duration: 0.5
         @l.stop()
         return false
@@ -131,7 +131,7 @@ define [
       formData =
         email: email
         amount: amount
-        backer: $("#list-me").prop("checked")
+        backer: $('#list-me').prop('checked')
 
       @data = _.extend stripeData, formData
 
@@ -143,7 +143,7 @@ define [
       @l.setProgress 0.7
 
       if response.error
-        @donateFormResponse("alert", [response.error.message])
+        @donateFormResponse('alert', [response.error.message])
       else
         attributes =
           amount: @data.amount * 100
@@ -154,30 +154,30 @@ define [
           backer: @data.backer
 
         $.ajax(
-          type: "POST"
-          url: jailbreak.api_host + "/stripe"
-          dataType: "json"
-          contentType: "application/json"
+          type: 'POST'
+          url: jailbreak.api_host + '/stripe'
+          dataType: 'json'
+          contentType: 'application/json'
           data: JSON.stringify(attributes)
         ).done (data) =>
           @l.setProgress 1.0
           if @iphoneRedirect
-            window.location = "jailbreak://"
+            window.location = 'jailbreak://'
           else
             @donationThankYou()
         .fail (err) =>
           @submitted = false
           if err.status == 500
-            @donateFormResponse("alert", ["We're suffering some technical difficulties please try again later today"])
+            @donateFormResponse('alert', ['We\'re suffering some technical difficulties please try again later today'])
           else
-            @donateFormResponse("alert", ["Donation failed: " + err.responseJSON.message])
+            @donateFormResponse('alert', ['Donation failed: ' + err.responseJSON.message])
 
     donationThankYou: =>
-      $("#donate-content").slideUp 300, =>
-        $("section.content").append jade.donationThankYou()
-        $("#donate-thank-you").slideDown 300
-        $("#donate-close").click () =>
+      $('#donate-content').slideUp 300, =>
+        $('section.content').append jade.donationThankYou()
+        $('#donate-thank-you').slideDown 300
+        $('#donate-close').click () =>
           if @parentView
             @parentView.closeDonateVex()
           else
-            window.location = "https://jailbreakhq.org"
+            window.location = 'https://jailbreakhq.org'

--- a/static/src/scripts/app/views/DonationsListView.coffee
+++ b/static/src/scripts/app/views/DonationsListView.coffee
@@ -1,20 +1,20 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "humanize"
-  "collections/DonationsCollection"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'humanize'
+  'collections/DonationsCollection'
 ], ($, _, Backbone, jade, Humanize, Donations) ->
   class DonationsList extends Backbone.View
     template: jade.teamDonations
 
     initialize: (options) =>
       if not options.collection
-        new Error("DonationsList view needs a collection in it's options")
+        new Error('DonationsList view needs a collection in it\'s options')
       @collection = options.collection
 
-      @listenTo @collection, "sync", @render
+      @listenTo @collection, 'sync', @render
 
       if options.template
         @template = options.template

--- a/static/src/scripts/app/views/DonationsListView.coffee
+++ b/static/src/scripts/app/views/DonationsListView.coffee
@@ -4,11 +4,12 @@ define [
   'backbone'
   'jade.templates'
   'mixen'
+  'mixens/BaseViewMixen'
   'mixens/CollectionViewMixen'
   'humanize'
   'collections/DonationsCollection'
-], ($, _, Backbone, jade, Mixen, CollectionViewMixen, Humanize, Donations) ->
-  class DonationsList extends Mixen(CollectionViewMixen, Backbone.View)
+], ($, _, Backbone, jade, Mixen, BaseView, CollectionView, Humanize, Donations) ->
+  class DonationsList extends Mixen(CollectionView, BaseView)
     template: jade.teamDonations
 
     initialize: (options) ->

--- a/static/src/scripts/app/views/DonationsListView.coffee
+++ b/static/src/scripts/app/views/DonationsListView.coffee
@@ -3,26 +3,28 @@ define [
   'underscore'
   'backbone'
   'jade.templates'
+  'mixen'
+  'mixens/CollectionViewMixen'
   'humanize'
   'collections/DonationsCollection'
-], ($, _, Backbone, jade, Humanize, Donations) ->
-  class DonationsList extends Backbone.View
+], ($, _, Backbone, jade, Mixen, CollectionViewMixen, Humanize, Donations) ->
+  class DonationsList extends Mixen(CollectionViewMixen, Backbone.View)
     template: jade.teamDonations
 
-    initialize: (options) =>
-      if not options.collection
-        new Error('DonationsList view needs a collection in it\'s options')
-      @collection = options.collection
-
-      @listenTo @collection, 'sync', @render
-
+    initialize: (options) ->
       if options.template
         @template = options.template
 
+      super
+
     render: =>
-      data =
+      context = @getRenderContext()
+      models =
         donations: _.map @collection.models, (val) -> val.getRenderContext()
         totalCount: @collection.totalCount
-      @$el.html @template data
+
+      context = _.extend context, models
+
+      @$el.html @template context
 
       @

--- a/static/src/scripts/app/views/ErrorView.coffee
+++ b/static/src/scripts/app/views/ErrorView.coffee
@@ -1,8 +1,8 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
 ], ($, _, Backbone, jade) ->
   class Error extends Backbone.View
     template: jade.error
@@ -12,7 +12,7 @@ define [
 
     render: =>
       if @error
-        @$el.html jade["error-" + @error]()
+        @$el.html jade["error-#{@error}"]()
       else
         @$el.html @template()
 

--- a/static/src/scripts/app/views/IndexStatsView.coffee
+++ b/static/src/scripts/app/views/IndexStatsView.coffee
@@ -1,18 +1,18 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "views/DonationFormView"
-  "vex"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'views/DonationFormView'
+  'vex'
 ], ($, _, Backbone, jade, DonationFormView, vex) ->
   class IndexStats extends Backbone.View
     template: jade.indexStats
     events:
-      "click .donate-button": "donate"
+      'click .donate-button': 'donate'
     
     initialize: =>
-      @listenTo @model, "sync change", @render
+      @listenTo @model, 'sync change', @render
 
     render: =>
       percent = (((@model.get('amountRaised') / 100) / 100000) * 100) or 0

--- a/static/src/scripts/app/views/IndexView.coffee
+++ b/static/src/scripts/app/views/IndexView.coffee
@@ -1,19 +1,19 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "collections/TeamsCollection"
-  "collections/DonationsCollection"
-  "collections/EventsCollection"
-  "models/JailbreakModel"
-  "views/TeamsMapView"
-  "views/TeamItemView"
-  "views/DonationsListView"
-  "views/IndexStatsView"
-  "views/feed/EventsListView"
-  "slick"
-  "async"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'collections/TeamsCollection'
+  'collections/DonationsCollection'
+  'collections/EventsCollection'
+  'models/JailbreakModel'
+  'views/TeamsMapView'
+  'views/TeamItemView'
+  'views/DonationsListView'
+  'views/IndexStatsView'
+  'views/feed/EventsListView'
+  'slick'
+  'async'
 ], ($, _, Backbone, jade, Teams, Donations, FeedEvents, Jailbreak, TeamsMapView, TeamItemView, DonationsListView, IndexStatsView, EventsListView, slick) ->
   class Index extends Backbone.View
     template: jade.index
@@ -34,9 +34,9 @@ define [
       @teamsMapView = new TeamsMapView
         settings: @jailbreakModel
         teams: @teams
-        mapElement: "index-map-canvas"
+        mapElement: 'index-map-canvas'
 
-      require ["async!//maps.googleapis.com/maps/api/js?v=3.exp&sensor=false"], (data) =>
+      require ['async!//maps.googleapis.com/maps/api/js?v=3.exp&sensor=false'], (data) =>
         @teamsMapView.googleMapsLoaded()
 
     render: =>
@@ -54,7 +54,7 @@ define [
       @slick()
 
     slick: ->
-      $(".video-slick", @$el).slick
+      $('.video-slick', @$el).slick
         centerMode: true
         variableWidth: true
         infinite: true
@@ -71,22 +71,22 @@ define [
           },
           {
             breakpoint: 640
-            settings: "unslick"
+            settings: 'unslick'
           }
         ]
 
     renderEventsStream: =>
       eventsListView = new EventsListView
         collection: @eventItems
-      $("#events-stream", @$el).append eventsListView.render().$el
+      $('#events-stream', @$el).append eventsListView.render().$el
 
     renderDonationsList: =>
       donationsListView = new DonationsListView
         collection: @donations
         template: jade.donations
-      $("#all-donations", @$el).append donationsListView.render().$el
+      $('#all-donations', @$el).append donationsListView.render().$el
 
     renderIndexStatsView: =>
       indexStatsView = new IndexStatsView
         model: @jailbreakModel
-      $("#index-stats", @$el).append indexStatsView.render().$el
+      $('#index-stats', @$el).append indexStatsView.render().$el

--- a/static/src/scripts/app/views/IndexView.coffee
+++ b/static/src/scripts/app/views/IndexView.coffee
@@ -48,10 +48,9 @@ define [
 
       @renderEventsStream()
 
-      @
-
-    afterRender: ->
       @slick()
+
+      @
 
     slick: ->
       $('.video-slick', @$el).slick

--- a/static/src/scripts/app/views/LoginView.coffee
+++ b/static/src/scripts/app/views/LoginView.coffee
@@ -1,16 +1,16 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "ladda"
-  "foundation.alert"
-  "animo"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'ladda'
+  'foundation.alert'
+  'animo'
 ], ($, _, Backbone, jade, Ladda) ->
   class LoginView extends Backbone.View
     template: jade.login
     events:
-      "click #submit-login": "login"
+      'click #submit-login': 'login'
 
     initialize: ->
       $('#body-container').addClass('login')
@@ -23,7 +23,7 @@ define [
     login: (event) =>
       event.preventDefault()
 
-      @l = Ladda.create document.querySelector "#submit-login"
+      @l = Ladda.create document.querySelector '#submit-login'
       @l.start()
 
       data =
@@ -32,36 +32,36 @@ define [
 
       valid = true
       if not data.email
-        $('#input-email').addClass "error-field"
+        $('#input-email').addClass 'error-field'
         valid = false
       else
-        $('#input-email').removeClass "error-field"
+        $('#input-email').removeClass 'error-field'
 
       if not data.password
-        $('#input-password').addClass "error-field"
+        $('#input-password').addClass 'error-field'
         valid = false
       else
-        $('#input-password').removeClass "error-field"
+        $('#input-password').removeClass 'error-field'
 
       if not valid
-        $("#login-form").animo
-          animation: "shake-subtle"
+        $('#login-form').animo
+          animation: 'shake-subtle'
           duration: 0.5
         @l.stop()
         return false
 
       $.ajax(
-        url: jailbreak.api_host + "/authenticate/login"
+        url: jailbreak.api_host + '/authenticate/login'
         data: JSON.stringify(data)
-        type: "POST"
-        contentType: "application/json"
-        dataType: "json"
+        type: 'POST'
+        contentType: 'application/json'
+        dataType: 'json'
       ).done((data, status) ->
-        localStorage.setItem "apiToken", JSON.stringify(data)
-        Backbone.history.navigate "admin", true
+        localStorage.setItem 'apiToken', JSON.stringify(data)
+        Backbone.history.navigate 'admin', true
       ).fail( ->
-        $("#login-form").animo
-          animation: "shake-subtle"
+        $('#login-form').animo
+          animation: 'shake-subtle'
           duration: 0.5
       ).always( =>
         @l.stop()

--- a/static/src/scripts/app/views/TeamItemView.coffee
+++ b/static/src/scripts/app/views/TeamItemView.coffee
@@ -1,17 +1,17 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "views/admin/AddCheckinFormView"
-  "vex"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'views/admin/AddCheckinFormView'
+  'vex'
 ], ($, _, Backbone, jade, AddCheckinView, vex) ->
   class TeamItem extends Backbone.View
-    tagName: "li"
-    className: "team"
+    tagName: 'li'
+    className: 'team'
     template: jade.teamListItem
     events:
-      "click .add-checkin": "addCheckin"
+      'click .add-checkin': 'addCheckin'
     
     initialize: (options) =>
       if options.template
@@ -20,7 +20,7 @@ define [
       if options.tagName
         @tagName = options.tagName
 
-      @model.bind "change sync", @render
+      @model.bind 'change sync', @render
 
       super
 

--- a/static/src/scripts/app/views/TeamListView.coffee
+++ b/static/src/scripts/app/views/TeamListView.coffee
@@ -4,10 +4,11 @@ define [
   'backbone'
   'jade.templates'
   'mixen'
+  'mixens/BaseViewMixen'
   'mixens/CollectionViewMixen'
   'views/TeamItemView'
-], ($, _, Backbone, jade, Mixen, CollectionViewMixen, TeamItemView) ->
-  class TeamList extends Mixen(CollectionViewMixen, Backbone.View)
+], ($, _, Backbone, jade, Mixen, BaseViewMixen, CollectionViewMixen, TeamItemView) ->
+  class TeamsList extends Mixen(CollectionViewMixen, BaseViewMixen)
     template: jade.teams
 
     initialize: (options) ->
@@ -17,9 +18,10 @@ define [
       context = @getRenderContext()
       @$el.html @template context
 
-      _.each @collection.models, (team) ->
+      _.each @collection.models, (team) =>
         teamView = new TeamItemView
           model: team
+        @rememberView teamView
         $('#teams').append teamView.render().$el
 
       @

--- a/static/src/scripts/app/views/TeamListView.coffee
+++ b/static/src/scripts/app/views/TeamListView.coffee
@@ -7,8 +7,8 @@ define [
   'mixens/BaseViewMixen'
   'mixens/CollectionViewMixen'
   'views/TeamItemView'
-], ($, _, Backbone, jade, Mixen, BaseViewMixen, CollectionViewMixen, TeamItemView) ->
-  class TeamsList extends Mixen(CollectionViewMixen, BaseViewMixen)
+], ($, _, Backbone, jade, Mixen, BaseView, CollectionView, TeamItemView) ->
+  class TeamsList extends Mixen(CollectionView, BaseView)
     template: jade.teams
 
     initialize: (options) ->

--- a/static/src/scripts/app/views/TeamListView.coffee
+++ b/static/src/scripts/app/views/TeamListView.coffee
@@ -1,28 +1,25 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "views/TeamItemView"
-], ($, _, Backbone, jade, TeamItemView) ->
-  class TeamList extends Backbone.View
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'mixen'
+  'mixens/CollectionViewMixen'
+  'views/TeamItemView'
+], ($, _, Backbone, jade, Mixen, CollectionViewMixen, TeamItemView) ->
+  class TeamList extends Mixen(CollectionViewMixen, Backbone.View)
     template: jade.teams
 
-    initialize: (options) =>
-      if not options.collection
-        new Error("TeamList view needs a collection in it's options")
-      @collection = options.collection
-      @.listenTo @collection, "sync", @render
+    initialize: (options) ->
+      super
 
     render: =>
-      data =
-        loaded: @collection.loaded
-
-      @$el.html @template data
+      context = @getRenderContext()
+      @$el.html @template context
 
       _.each @collection.models, (team) ->
         teamView = new TeamItemView
           model: team
-        $("#teams").append teamView.render().$el
+        $('#teams').append teamView.render().$el
 
       @

--- a/static/src/scripts/app/views/TeamMapView.coffee
+++ b/static/src/scripts/app/views/TeamMapView.coffee
@@ -1,18 +1,18 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "moment"
-  "humanize"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'moment'
+  'humanize'
 ], ($, _, Backbone, jade, moment) ->
   class TeamMapView extends Backbone.View
 
     initialize: (options) =>
       @checkins = options.checkins
-      @mapElement = options.mapElement or "map-canvas"
+      @mapElement = options.mapElement or 'map-canvas'
 
-      @listenTo @checkins, "sync", @renderTeamCheckins
+      @listenTo @checkins, 'sync', @renderTeamCheckins
 
     renderMap: =>
       mapOptions =
@@ -29,7 +29,7 @@ define [
     renderTeamMarkers: =>
       markerBounds = new google.maps.LatLngBounds()
       infowindow = new google.maps.InfoWindow
-        content: "Loading..."
+        content: 'Loading...'
 
       markers = []
       route = []

--- a/static/src/scripts/app/views/TeamProfileView.coffee
+++ b/static/src/scripts/app/views/TeamProfileView.coffee
@@ -5,6 +5,8 @@ define [
   'foundation'
   'foundation.tabs'
   'jade.templates'
+  'mixen'
+  'mixens/BaseViewMixen'
   'collections/DonationsCollection'
   'collections/EventsCollection'
   'collections/CheckinsCollection'
@@ -14,8 +16,8 @@ define [
   'views/feed/EventsListView'
   'vex'
   'autolink'
-], ($, _, Backbone, foundation, tabs, jade, Donations, FeedEvents, Checkins, DonationsListView, DonationFormView, TeamMapView, EventsListView, vex, autolink) ->
-  class TeamProfile extends Backbone.View
+], ($, _, Backbone, foundation, tabs, jade, Mixen, BaseView, Donations, FeedEvents, Checkins, DonationsListView, DonationFormView, TeamMapView, EventsListView, vex, autolink) ->
+  class TeamProfile extends Mixen(BaseView)
     template: jade.team
     events:
       'click .team-avatar.avatar-large': 'openLargeAvatar'
@@ -58,11 +60,13 @@ define [
     renderDonationsList: =>
       donationsListView = new DonationsListView
         collection: @donations
+      @rememberView donationsListView
       $('#donations-panel', @$el).html donationsListView.render().$el
 
     renderStoryEvents: =>
       eventsListView = new EventsListView
         collection: @storyEvents
+      @rememberView eventsListView
       $('#team-story', @$el).append eventsListView.render().$el
 
     renderTeamMap: =>
@@ -72,6 +76,7 @@ define [
           mapElement: 'team-map'
         checkinsMapView.renderMap()
         checkinsMapView.renderTeamMarkers()
+        @rememberView checkinsMapView
 
     openLargeAvatar: (event) =>
       displayVex = =>

--- a/static/src/scripts/app/views/TeamsCardView.coffee
+++ b/static/src/scripts/app/views/TeamsCardView.coffee
@@ -1,8 +1,8 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
 ], ($, _, Backbone, jade) ->
   class TeamCardView extends Backbone.View
     template: jade.teamCard
@@ -10,7 +10,7 @@ define [
     initialize: (options) =>
       if options.template
         @template = options.template
-      @model.bind "change", @render
+      @model.bind 'change', @render
 
     render: =>
       @$el.html @template @model.getRenderContext()

--- a/static/src/scripts/app/views/TeamsListView.coffee
+++ b/static/src/scripts/app/views/TeamsListView.coffee
@@ -10,10 +10,7 @@ define [
 ], ($, _, Backbone, jade, Mixen, BaseView, CollectionView, TeamItemView) ->
   class TeamsList extends Mixen(CollectionView, BaseView)
     template: jade.teams
-
-    initialize: (options) ->
-      super
-
+    
     render: =>
       context = @getRenderContext()
       @$el.html @template context

--- a/static/src/scripts/app/views/TeamsMapView.coffee
+++ b/static/src/scripts/app/views/TeamsMapView.coffee
@@ -1,12 +1,12 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "collections/TeamsCollection"
-  "models/JailbreakModel"
-  "moment"
-  "humanize"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'collections/TeamsCollection'
+  'models/JailbreakModel'
+  'moment'
+  'humanize'
 ], ($, _, Backbone, jade, Teams, Jailbreak, moment) ->
   class TeamsMapView extends Backbone.View
 
@@ -15,10 +15,10 @@ define [
       @settings = options.settings
       @teams = options.teams
 
-      @listenTo @settings, "sync", @renderMap
-      @listenTo @teams, "sync", @renderTeamMarkers
+      @listenTo @settings, 'sync', @renderMap
+      @listenTo @teams, 'sync', @renderTeamMarkers
 
-      @mapElement = options.mapElement or "map-canvas"
+      @mapElement = options.mapElement or 'map-canvas'
 
     googleMapsLoaded: =>
       @loadedMaps = true
@@ -49,7 +49,7 @@ define [
       @map = new google.maps.Map document.getElementById(@mapElement), mapOptions
       @markerBounds = new google.maps.LatLngBounds()
       @infowindow = new google.maps.InfoWindow
-        content: "Loading..."
+        content: 'Loading...'
 
       # start and end markers
       @startMarker = new google.maps.Marker
@@ -59,8 +59,8 @@ define [
           path: google.maps.SymbolPath.CIRCLE
           scale: 6
           strokeColor: '#b21c26'
-        title: "Start Point"
-        html: """<div class="info-window"><h3>Collins Barracks, Dublin</h3><p>The start point of the Jailbreak 2015 race</p></div>"""
+        title: 'Start Point'
+        html: '''<div class='info-window'><h3>Collins Barracks, Dublin</h3><p>The start point of the Jailbreak 2015 race</p></div>'''
 
       google.maps.event.addListener @startMarker, 'click', (startMarker) =>
         @infowindow.setContent @startMarker.html
@@ -76,15 +76,15 @@ define [
           path: google.maps.SymbolPath.CIRCLE
           scale: 6
           strokeColor: '#b21c26'
-        title: "Location X"
-        html: """
-            <div class="info-window">
+        title: 'Location X'
+        html: '''
+            <div class='info-window'>
               <h3>Location X</h3>
               <p>The Bled Castle overlooking Lake Bled, Slovenia!</p>
               <br/>
-              <img src="https://static.jailbreakhq.org/bled-castle.jpg" height="300" />
+              <img src='https://static.jailbreakhq.org/bled-castle.jpg' height='300' />
             </div>
-          """
+          '''
 
       google.maps.event.addListener @endMarker, 'click', (endMarker) =>
         @infowindow.setContent @endMarker.html
@@ -111,7 +111,7 @@ define [
           marker = new google.maps.Marker
             position: new google.maps.LatLng(team.get('lastCheckin').get('lat'), team.get('lastCheckin').get('lon'))
             map: @map
-            title: team.teamNumber + " " + team.names
+            title: team.teamNumber + ' ' + team.names
             html: jade.mapsMarker team.getRenderContext()
             animation: google.maps.Animation.DROP
   

--- a/static/src/scripts/app/views/TopTeamsCardListView.coffee
+++ b/static/src/scripts/app/views/TopTeamsCardListView.coffee
@@ -3,22 +3,23 @@ define [
   'underscore'
   'backbone'
   'jade.templates'
+  'mixen'
+  'mixens/BaseViewMixen'
+  'mixens/CollectionViewMixen'
   'views/TeamsCardView'
-], ($, _, Backbone, jade, TeamsCardView) ->
-  class TopTeamsCardListView extends Backbone.View
-
-    initialize: (options) =>
-      if not options.collection
-        new Error('TopTeamsCardListView needs a collection in it\'s options')
-      @collection = options.collection
-
-      @listenTo @collection, 'sync', @render
+  'humanize'
+], ($, _, Backbone, jade, Mixen, BaseView, CollectionView, TeamsCardView, Humanize) ->
+  class TopTeamsCardListView extends Mixen(CollectionView, BaseView)
+    template: jade.iframeLeaders
 
     render: =>
+      context = @getRenderContext()
+      $('#leaders').html @template context
+
       top = _.first @collection.models, 2
       _.each top, (team) ->
         teamCardView = new TeamsCardView
           model: team
-        $('#leaders').append teamCardView.render().$el
+        $('#leaders-list').append teamCardView.render().$el
 
       @

--- a/static/src/scripts/app/views/TopTeamsCardListView.coffee
+++ b/static/src/scripts/app/views/TopTeamsCardListView.coffee
@@ -1,24 +1,24 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "views/TeamsCardView"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'views/TeamsCardView'
 ], ($, _, Backbone, jade, TeamsCardView) ->
   class TopTeamsCardListView extends Backbone.View
 
     initialize: (options) =>
       if not options.collection
-        new Error("TopTeamsCardListView needs a collection in it's options")
+        new Error('TopTeamsCardListView needs a collection in it\'s options')
       @collection = options.collection
 
-      @listenTo @collection, "sync", @render
+      @listenTo @collection, 'sync', @render
 
     render: =>
       top = _.first @collection.models, 2
       _.each top, (team) ->
         teamCardView = new TeamsCardView
           model: team
-        $("#leaders").append teamCardView.render().$el
+        $('#leaders').append teamCardView.render().$el
 
       @

--- a/static/src/scripts/app/views/admin/AddCheckinFormView.coffee
+++ b/static/src/scripts/app/views/admin/AddCheckinFormView.coffee
@@ -1,29 +1,29 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "models/PositionModel"
-  "models/CheckinModel"
-  "ladda"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'models/PositionModel'
+  'models/CheckinModel'
+  'ladda'
 ], ($, _, Backbone, jade, Position, Checkin, Ladda) ->
   class AddCheckinForm extends Backbone.View
     template: jade.adminAddCheckin
     events:
-      "click #submit-add-checkin": "addCheckin"
+      'click #submit-add-checkin': 'addCheckin'
     
     initialize: (options) =>
       if not options.team
-        throw new Error("AddCheckinView requires a team id")
+        throw new Error('AddCheckinView requires a team id')
       @team = options.team
 
       @parent = options.parent
 
       @position = new Position
-      @listenTo @position, "change", @renderInputs
+      @listenTo @position, 'change', @renderInputs
 
       # Load google map by inserting new script into the page
-      require ["async!//maps.googleapis.com/maps/api/js?v=3.exp&sensor=false&libraries=places"], (data) =>
+      require ['async!//maps.googleapis.com/maps/api/js?v=3.exp&sensor=false&libraries=places'], (data) =>
         @renderMap()
 
       super
@@ -36,12 +36,12 @@ define [
       @
 
     renderInputs: =>
-      $("#position-inputs", @$el).html jade.adminAddCheckinInputs @position.toJSON()
+      $('#position-inputs', @$el).html jade.adminAddCheckinInputs @position.toJSON()
 
     renderMap: =>
       if @team.has 'lastCheckin'
-        centerLat = @team.get('lastCheckin').get('lat')
-        centerLon = @team.get('lastCheckin').get('lon')
+        centerLat = @team.get('lastCheckin').get 'lat'
+        centerLon = @team.get('lastCheckin').get 'lon'
       else
         centerLat = 53.348857
         centerLon = -6.285844
@@ -57,14 +57,14 @@ define [
       
       map = new google.maps.Map document.getElementById('map-canvas'), mapOptions
       infowindow = new google.maps.InfoWindow
-        content: "Loading..."
+        content: 'Loading...'
 
-      input = document.getElementById "input-autocomplete"
+      input = document.getElementById 'input-autocomplete'
 
       map.controls[google.maps.ControlPosition.TOP_LEFT].push(input)
 
       autocomplete = new google.maps.places.Autocomplete input
-      autocomplete.bindTo "bounds", map
+      autocomplete.bindTo 'bounds', map
 
       marker = new google.maps.Marker
         map: map,
@@ -94,7 +94,7 @@ define [
         marker.setPosition(place.geometry.location)
         marker.setVisible(true)
 
-        address = ""
+        address = ''
         if place.address_components
           address = [
             (place.address_components[0] && place.address_components[0].short_name || ''),
@@ -107,44 +107,44 @@ define [
 
         location = place.name
         if place.address_components[3]
-          location += ", " + place.address_components[3].long_name
+          location += ', ' + place.address_components[3].long_name
         else if place.vicinity
-          location += ", " + place.vicinity
+          location += ', ' + place.vicinity
 
         # update the model and re-render the actual input fields
-        @position.set "lat", place.geometry.location.k
-        @position.set "lon", place.geometry.location.D
-        @position.set "location", location
+        @position.set 'lat', place.geometry.location.k
+        @position.set 'lon', place.geometry.location.D
+        @position.set 'location', location
 
     addCheckin: (event) ->
       event.preventDefault()
 
       data =
-        lat: parseFloat $("#input-lat", @$el).val()
-        lon: parseFloat $("#input-lon", @$el).val()
-        location: $("#input-location", @$el).val()
-        status: $("#input-status", @$el).val()
+        lat: parseFloat $('#input-lat', @$el).val()
+        lon: parseFloat $('#input-lon', @$el).val()
+        location: $('#input-location', @$el).val()
+        status: $('#input-status', @$el).val()
         teamId: @team.get 'id'
 
-      l = Ladda.create document.getElementById "submit-add-checkin"
+      l = Ladda.create document.getElementById 'submit-add-checkin'
       l.start()
 
       valid = true
-      if not @checkField data.lat, "#input-lat"
+      if not @checkField data.lat, '#input-lat'
         valid = false
 
-      if not @checkField data.lon, "#input-lon"
+      if not @checkField data.lon, '#input-lon'
         valid = false
 
-      if not @checkField data.location, "#input-location"
+      if not @checkField data.location, '#input-location'
         valid = false
 
-      if not @checkField data.status, "#input-status"
+      if not @checkField data.status, '#input-status'
         valid = false
 
       if not valid
-        $("form", @$el).animo
-          animation: "shake-subtle"
+        $('form', @$el).animo
+          animation: 'shake-subtle'
           duration: 0.5
         l.stop()
         return false
@@ -159,14 +159,14 @@ define [
           @parent.closeVex()
         error: (model, error) =>
           l.stop()
-          $("form", @$el).animo
-            animation: "shake-subtle"
+          $('form', @$el).animo
+            animation: 'shake-subtle'
             duration: 0.5
 
     checkField: (value, selector) ->
       if not value
-        $(selector, @$el).addClass "error-field"
+        $(selector, @$el).addClass 'error-field'
         return false
       else
-        $(selector, @$el).removeClass "error-field"
+        $(selector, @$el).removeClass 'error-field'
         return true

--- a/static/src/scripts/app/views/admin/AddDonateFormView.coffee
+++ b/static/src/scripts/app/views/admin/AddDonateFormView.coffee
@@ -1,28 +1,28 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "models/TeamModel"
-  "models/feed/DonateEventModel"
-  "views/feed/DonateView"
-  "ladda"
-  "messenger"
-  "select2"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'models/TeamModel'
+  'models/feed/DonateEventModel'
+  'views/feed/DonateView'
+  'ladda'
+  'messenger'
+  'select2'
 ], ($, _, Backbone, jade, Team, DonateEvent, DonateView, Ladda, Messenger, Select2) ->
   class AddSocialForm extends Backbone.View
     template: jade.adminAddDonate
     events:
-      "click #submit-add-donate": "addDonate"
-      "input #input-donate-text": "updateDonateText"
-      "input #input-donate-description": "updateDonateDescription"
+      'click #submit-add-donate': 'addDonate'
+      'input #input-donate-text': 'updateDonateText'
+      'input #input-donate-description': 'updateDonateDescription'
     
     initialize: (options) =>
       @teams = options.teams
       @model = new DonateEvent
 
-      @.listenTo @model, "change", @renderPreview
-      @.listenTo @teams, "sync", @render
+      @.listenTo @model, 'change', @renderPreview
+      @.listenTo @teams, 'sync', @render
 
       super
 
@@ -33,20 +33,20 @@ define [
         teams: teamsContext
       @$el.html @template context
 
-      $("select", @$el).select2().on("change", @updateDonateTeamId)
+      $('select', @$el).select2().on('change', @updateDonateTeamId)
 
       @
 
     renderPreview: (event) ->
       donatePreview = new DonateView
         model: @model
-      $("#donate-preview", @$el).html donatePreview.render().$el
+      $('#donate-preview', @$el).html donatePreview.render().$el
 
     updateDonateText: (event) ->
-      @model.set 'linkText', $("#input-donate-text", @$el).val()
+      @model.set 'linkText', $('#input-donate-text', @$el).val()
 
     updateDonateDescription: (event) ->
-      @model.set 'description', $("#input-donate-description", @$el).val()
+      @model.set 'description', $('#input-donate-description', @$el).val()
 
     updateDonateTeamId: (event) =>
       team = new Team
@@ -61,45 +61,45 @@ define [
       event.preventDefault()
 
       data =
-        linkText: $("#input-donate-text", @$el).val()
-        description: $("#input-donate-description", @$el).val()
-        teamId: $("#input-donate-team-id", @$el).val() or null
+        linkText: $('#input-donate-text', @$el).val()
+        description: $('#input-donate-description', @$el).val()
+        teamId: $('#input-donate-team-id', @$el).val() or null
 
-      l = Ladda.create document.getElementById "submit-add-donate"
+      l = Ladda.create document.getElementById 'submit-add-donate'
       l.start()
 
       valid = true
-      if not @checkField data.linkText, "#input-donate-text"
+      if not @checkField data.linkText, '#input-donate-text'
         valid = false
 
-      if not @checkField data.description, "#input-donate-description"
+      if not @checkField data.description, '#input-donate-description'
         valid = false
 
       if not valid
-        $("form", @$el).animo
-          animation: "shake-subtle"
+        $('form', @$el).animo
+          animation: 'shake-subtle'
           duration: 0.5
         l.stop()
         return false
 
       @model.save {},
         success: (model, response) ->
-          Messenger().post "Donate button added to news feed"
+          Messenger().post 'Donate button added to news feed'
           l.stop()
         error: (model, error) =>
           Messenger().post
-            message: "There was a problem. Talk to Kevin. " + error.message
-            type: "error"
+            message: 'There was a problem. Talk to Kevin. ' + error.message
+            type: 'error'
             showCloseButton: true
           l.stop()
-          $("form", @$el).animo
-            animation: "shake-subtle"
+          $('form', @$el).animo
+            animation: 'shake-subtle'
             duration: 0.5
 
     checkField: (value, selector) ->
       if not value
-        $(selector, @$el).addClass "error-field"
+        $(selector, @$el).addClass 'error-field'
         return false
       else
-        $(selector, @$el).removeClass "error-field"
+        $(selector, @$el).removeClass 'error-field'
         return true

--- a/static/src/scripts/app/views/admin/AddFeedView.coffee
+++ b/static/src/scripts/app/views/admin/AddFeedView.coffee
@@ -1,16 +1,16 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "foundation"
-  "foundation.tabs"
-  "jade.templates"
-  "mixen"
-  "mixens/RequiresLoginMixen"
-  "collections/TeamsCollection"
-  "views/admin/AddLinkFormView"
-  "views/admin/AddDonateFormView"
-  "views/admin/AddSocialFormView"
+  'jquery'
+  'underscore'
+  'backbone'
+  'foundation'
+  'foundation.tabs'
+  'jade.templates'
+  'mixen'
+  'mixens/RequiresLoginMixen'
+  'collections/TeamsCollection'
+  'views/admin/AddLinkFormView'
+  'views/admin/AddDonateFormView'
+  'views/admin/AddSocialFormView'
 ], ($, _, Backbone, foundation, tabs, jade, Mixen, RequiresLoginMixen, Teams, AddLinkFormView, AddDonateFormView, AddSocialFormView) ->
   class AdminFeedView extends Mixen(RequiresLoginMixen, Backbone.View)
     template: jade.adminAddFeed
@@ -36,14 +36,14 @@ define [
 
     renderLinkForm: ->
       linkFormView = new AddLinkFormView
-      $("#links-panel", @$el).html linkFormView.render().$el
+      $('#links-panel', @$el).html linkFormView.render().$el
 
     renderDonateForm: ->
       donateFormView = new AddDonateFormView
         teams: @teams
-      $("#donate-panel", @$el).html donateFormView.render().$el
+      $('#donate-panel', @$el).html donateFormView.render().$el
 
     renderSocialForm: ->
       socialFormView = new AddSocialFormView
         teams: @teams
-      $("#social-panel", @$el).html socialFormView.render().$el
+      $('#social-panel', @$el).html socialFormView.render().$el

--- a/static/src/scripts/app/views/admin/AddLinkFormView.coffee
+++ b/static/src/scripts/app/views/admin/AddLinkFormView.coffee
@@ -1,26 +1,26 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "models/feed/LinkEventModel"
-  "views/feed/LinkView"
-  "ladda"
-  "messenger"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'models/feed/LinkEventModel'
+  'views/feed/LinkView'
+  'ladda'
+  'messenger'
 ], ($, _, Backbone, jade, LinkEvent, LinkView, Ladda, Messenger) ->
   class AddLinkForm extends Backbone.View
     template: jade.adminAddLink
     events:
-      "click #submit-add-link": "addLink"
-      "input #input-link-url": "updateLinkUrl"
-      "input #input-link-text": "updateLinkText"
-      "input #input-link-description": "updateLinkDescription"
-      "input #input-link-photo-url": "updateLinkPhotoUrl"
+      'click #submit-add-link': 'addLink'
+      'input #input-link-url': 'updateLinkUrl'
+      'input #input-link-text': 'updateLinkText'
+      'input #input-link-description': 'updateLinkDescription'
+      'input #input-link-photo-url': 'updateLinkPhotoUrl'
     
     initialize: (options) =>
       @link = new LinkEvent
 
-      @.listenTo @link, "change", @renderPreview
+      @.listenTo @link, 'change', @renderPreview
 
       super
 
@@ -32,67 +32,67 @@ define [
     renderPreview: (event) ->
       linkPreview = new LinkView
         model: @link
-      $("#link-preview", @$el).html linkPreview.render().$el
+      $('#link-preview', @$el).html linkPreview.render().$el
 
     updateLinkUrl: (event) ->
-      @link.set 'url', $("#input-link-url", @$el).val()
+      @link.set 'url', $('#input-link-url', @$el).val()
 
     updateLinkText: (event) ->
-      @link.set 'linkText', $("#input-link-text", @$el).val()
+      @link.set 'linkText', $('#input-link-text', @$el).val()
 
     updateLinkDescription: (event) ->
-      @link.set 'description', $("#input-link-description", @$el).val()
+      @link.set 'description', $('#input-link-description', @$el).val()
 
     updateLinkPhotoUrl: (event) ->
-      @link.set 'photoUrl', $("#input-link-photo-url", @$el).val()
+      @link.set 'photoUrl', $('#input-link-photo-url', @$el).val()
 
     addLink: (event) ->
       event.preventDefault()
 
       data =
-        url: $("#input-link-url", @$el).val()
-        linkText: $("#input-link-text", @$el).val()
-        description: $("#input-link-description", @$el).val()
-        photoUrl: $("#input-link-photo-url", @$el).val()
+        url: $('#input-link-url', @$el).val()
+        linkText: $('#input-link-text', @$el).val()
+        description: $('#input-link-description', @$el).val()
+        photoUrl: $('#input-link-photo-url', @$el).val()
 
-      l = Ladda.create document.getElementById "submit-add-link"
+      l = Ladda.create document.getElementById 'submit-add-link'
       l.start()
 
       valid = true
-      if not @checkField data.url, "#input-link-url"
+      if not @checkField data.url, '#input-link-url'
         valid = false
 
-      if not @checkField data.linkText, "#input-link-text"
+      if not @checkField data.linkText, '#input-link-text'
         valid = false
 
-      if not @checkField data.description, "#input-link-description"
+      if not @checkField data.description, '#input-link-description'
         valid = false
 
       if not valid
-        $("form", @$el).animo
-          animation: "shake-subtle"
+        $('form', @$el).animo
+          animation: 'shake-subtle'
           duration: 0.5
         l.stop()
         return false
 
       @link.save {},
         success: (model, response) ->
-          Messenger().post "Link posted to news feed"
+          Messenger().post 'Link posted to news feed'
           l.stop()
         error: (model, error) =>
           Messenger().post
-            message: "There was a problem. Talk to Kevin. " + error.message
-            type: "error"
+            message: 'There was a problem. Talk to Kevin. ' + error.message
+            type: 'error'
             showCloseButton: true
           l.stop()
-          $("form", @$el).animo
-            animation: "shake-subtle"
+          $('form', @$el).animo
+            animation: 'shake-subtle'
             duration: 0.5
 
     checkField: (value, selector) ->
       if not value
-        $(selector, @$el).addClass "error-field"
+        $(selector, @$el).addClass 'error-field'
         return false
       else
-        $(selector, @$el).removeClass "error-field"
+        $(selector, @$el).removeClass 'error-field'
         return true

--- a/static/src/scripts/app/views/admin/AddSocialFormView.coffee
+++ b/static/src/scripts/app/views/admin/AddSocialFormView.coffee
@@ -1,18 +1,18 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "ladda"
-  "messenger"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'ladda'
+  'messenger'
 ], ($, _, Backbone, jade, Ladda, Messenger) ->
   class AddSocialForm extends Backbone.View
     template: jade.adminAddSocial
     events:
-      "click #submit-add-donate": "addDonate"
-      "input #input-donate-text": "updateDonateText"
-      "input #input-donate-description": "updateDonateDescription"
-      "input #input-donate-team-id": "updateDonateTeamId"
+      'click #submit-add-donate': 'addDonate'
+      'input #input-donate-text': 'updateDonateText'
+      'input #input-donate-description': 'updateDonateDescription'
+      'input #input-donate-team-id': 'updateDonateTeamId'
     
     initialize: (options) =>
 

--- a/static/src/scripts/app/views/admin/MainView.coffee
+++ b/static/src/scripts/app/views/admin/MainView.coffee
@@ -1,19 +1,19 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "mixen"
-  "mixens/RequiresLoginMixen"
-  "views/TeamItemView"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'mixen'
+  'mixens/RequiresLoginMixen'
+  'views/TeamItemView'
 ], ($, _, Backbone, jade, Mixen, RequiresLoginMixen, TeamItemView) ->
   class AdminView extends Mixen(RequiresLoginMixen, Backbone.View)
     template: jade.adminMain
 
     initialize: (options) ->
       @teams = options.teams
-      @.listenTo @teams, "sync", @renderTeams
-      @.listenTo @teams, "change", @renderTeams
+      @.listenTo @teams, 'sync', @renderTeams
+      @.listenTo @teams, 'change', @renderTeams
 
       super
 
@@ -25,7 +25,7 @@ define [
       @
 
     renderTeams: =>
-      list = $("#teams").empty()
+      list = $('#teams').empty()
 
       @teams.sort()
 
@@ -33,5 +33,5 @@ define [
         teamView = new TeamItemView
           model: team
           template: jade.teamCheckinOverview
-          tagName: "tr"
+          tagName: 'tr'
         list.append teamView.render().$el

--- a/static/src/scripts/app/views/feed/CheckinView.coffee
+++ b/static/src/scripts/app/views/feed/CheckinView.coffee
@@ -1,14 +1,14 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
 ], ($, _, Backbone, jade) ->
   class CheckinView extends Backbone.View
     template: jade.feedCheckin
     
     initialize: (options) =>
-      @listenTo @model, "change", @render
+      @listenTo @model, 'change', @render
 
       super
 

--- a/static/src/scripts/app/views/feed/DonateView.coffee
+++ b/static/src/scripts/app/views/feed/DonateView.coffee
@@ -1,14 +1,14 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
 ], ($, _, Backbone, jade) ->
   class DonateView extends Backbone.View
     template: jade.feedDonate
     
     initialize: (options) =>
-      @listenTo @model, "change", @render
+      @listenTo @model, 'change', @render
 
       super
 

--- a/static/src/scripts/app/views/feed/EventsListView.coffee
+++ b/static/src/scripts/app/views/feed/EventsListView.coffee
@@ -9,22 +9,17 @@ define [
   'views/feed/DonateView'
   'views/feed/LinkView'
   'views/feed/CheckinView'
-], ($, _, Backbone, jade, Mixen, BaseView, CollectionView, DonateView, LinkView, CheckinView) ->
-  class EventsListView extends Mixen(CollectionView, BaseView)
+], ($, _, Backbone, jade, Mixen, BaseViewMixen, CollectionViewMixen, DonateView, LinkView, CheckinView) ->
+  class EventsListView extends Mixen(CollectionViewMixen, BaseViewMixen)
     template: jade.feedList
-
-    initialize: (options) ->
-      super
 
     render: =>
       context = @getRenderContext()
       @$el.html @template context
 
-      @renderEvents()
-
       @
 
-    renderEvents: =>
+    renderCollection: =>
       htmlList = $('#events-stream-list', @$el)
       for feedEvent in @collection.models
         switch feedEvent.get 'type'

--- a/static/src/scripts/app/views/feed/EventsListView.coffee
+++ b/static/src/scripts/app/views/feed/EventsListView.coffee
@@ -13,8 +13,6 @@ define [
     template: jade.feedList
 
     initialize: (options) =>
-      @collection = options.collection
-
       super
 
     render: =>

--- a/static/src/scripts/app/views/feed/EventsListView.coffee
+++ b/static/src/scripts/app/views/feed/EventsListView.coffee
@@ -1,43 +1,47 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
-  "views/feed/DonateView"
-  "views/feed/LinkView"
-  "views/feed/CheckinView"
-], ($, _, Backbone, jade, DonateView, LinkView, CheckinView) ->
-  class EventsListView extends Backbone.View
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
+  'mixen'
+  'mixens/CollectionViewMixen'
+  'views/feed/DonateView'
+  'views/feed/LinkView'
+  'views/feed/CheckinView'
+], ($, _, Backbone, jade, Mixen, CollectionViewMixen, DonateView, LinkView, CheckinView) ->
+  class EventsListView extends Mixen(CollectionViewMixen, Backbone.View)
     template: jade.feedList
 
     initialize: (options) =>
       @collection = options.collection
 
-      @listenTo @collection, "sync", @renderEvents
-
       super
 
     render: =>
-      @$el.html @template()
+      context = @getRenderContext()
+      @$el.html @template context
+
+      @renderEvents()
+
       @
 
     renderEvents: =>
-      htmlList = $("#events-stream-list", @$el)
+      htmlList = $('#events-stream-list', @$el)
       for feedEvent in @collection.models
         switch feedEvent.get 'type'
-          when "DONATE"
+          when 'DONATE'
             donate = feedEvent.get 'donate'
             donate.set 'time', feedEvent.get 'time'
             donateView = new DonateView
               model: donate
             htmlList.append donateView.render().$el
-          when "LINK"
+          when 'LINK'
             link = feedEvent.get 'link'
             link.set 'time', feedEvent.get 'time'
             linkView = new LinkView
               model: link
             htmlList.append linkView.render().$el
-          when "CHECKIN"
+          when 'CHECKIN'
             checkin = feedEvent.get 'checkin'
             checkinView = new CheckinView
               model: checkin

--- a/static/src/scripts/app/views/feed/EventsListView.coffee
+++ b/static/src/scripts/app/views/feed/EventsListView.coffee
@@ -4,15 +4,16 @@ define [
   'backbone'
   'jade.templates'
   'mixen'
+  'mixens/BaseViewMixen'
   'mixens/CollectionViewMixen'
   'views/feed/DonateView'
   'views/feed/LinkView'
   'views/feed/CheckinView'
-], ($, _, Backbone, jade, Mixen, CollectionViewMixen, DonateView, LinkView, CheckinView) ->
-  class EventsListView extends Mixen(CollectionViewMixen, Backbone.View)
+], ($, _, Backbone, jade, Mixen, BaseView, CollectionView, DonateView, LinkView, CheckinView) ->
+  class EventsListView extends Mixen(CollectionView, BaseView)
     template: jade.feedList
 
-    initialize: (options) =>
+    initialize: (options) ->
       super
 
     render: =>
@@ -33,14 +34,17 @@ define [
             donateView = new DonateView
               model: donate
             htmlList.append donateView.render().$el
+            @rememberView donateView
           when 'LINK'
             link = feedEvent.get 'link'
             link.set 'time', feedEvent.get 'time'
             linkView = new LinkView
               model: link
             htmlList.append linkView.render().$el
+            @rememberView linkView
           when 'CHECKIN'
             checkin = feedEvent.get 'checkin'
             checkinView = new CheckinView
               model: checkin
             htmlList.append checkinView.render().$el
+            @rememberView checkinView

--- a/static/src/scripts/app/views/feed/LinkView.coffee
+++ b/static/src/scripts/app/views/feed/LinkView.coffee
@@ -1,14 +1,14 @@
 define [
-  "jquery"
-  "underscore"
-  "backbone"
-  "jade.templates"
+  'jquery'
+  'underscore'
+  'backbone'
+  'jade.templates'
 ], ($, _, Backbone, jade) ->
   class LinkView extends Backbone.View
     template: jade.feedLink
     
     initialize: (options) =>
-      @listenTo @model, "change", @render
+      @listenTo @model, 'change', @render
 
       super
 

--- a/static/src/scripts/common.coffee
+++ b/static/src/scripts/common.coffee
@@ -1,4 +1,5 @@
 requirejs.config
+  waitSeconds: 15
   baseUrl: '/build/scripts/app'
   paths:
     'jquery': '../../../components/jquery/dist/jquery',

--- a/static/src/scripts/common.coffee
+++ b/static/src/scripts/common.coffee
@@ -1,93 +1,93 @@
 requirejs.config
-  baseUrl: "/build/scripts/app"
+  baseUrl: '/build/scripts/app'
   paths:
-    "jquery": "../../../components/jquery/dist/jquery",
-    "underscore": "../../../components/underscore/underscore"
-    "backbone": "../../../components/backbone/backbone"
-    "moment": "../../../components/moment/moment"
-    "humanize": "../../../components/humanize-plus/public/dist/humanize.min"
-    "jade": "../../../components/jade/runtime"
-    "raven": "../../../components/raven-js/dist/raven"
-    "mixen": "../../../components/mixen/mixen.min"
-    "vex": "../../../components/vex/js/vex"
-    "vex.dialog": "../../../components/vex/js/vex.dialog"
-    "modernizr": "../../../components/modernizr/modernizr"
-    "foundation": "../../../components/bower-foundation/js/foundation/foundation"
-    "foundation.tabs": "../../../components/bower-foundation/js/foundation/foundation.tab"
-    "foundation.topbar": "../../../components/bower-foundation/js/foundation/foundation.topbar"
-    "foundation.tooltip": "../../../components/bower-foundation/js/foundation/foundation.tooltip"
-    "foundation.alert": "../../../components/bower-foundation/js/foundation/foundation.alert"
-    "autolink": "../../../components/autolink/autolink-min"
-    "jquery.countdown": "../../../components/jquery.countdown/dist/jquery.countdown.min"
-    "jquery.payment": "../../../components/jquery.payment/lib/jquery.payment"
-    "slick": "../../../components/slick.js/slick/slick"
-    "animo": "../../../components/animo.js/animo"
-    "ladda": "../../../components/ladda/js/ladda"
-    "spin": "../../../components/ladda/js/spin"
-    "signet": "../../../components/signet/signet"
-    "messenger": "../../../components/messenger/build/js/messenger"
-    "select2": "../../../components/select2/select2"
-    "async": "../../../components/requirejs-plugins/src/async"
-    "jade.templates": "../../templates/jade"
+    'jquery': '../../../components/jquery/dist/jquery',
+    'underscore': '../../../components/underscore/underscore'
+    'backbone': '../../../components/backbone/backbone'
+    'moment': '../../../components/moment/moment'
+    'humanize': '../../../components/humanize-plus/public/dist/humanize.min'
+    'jade': '../../../components/jade/runtime'
+    'raven': '../../../components/raven-js/dist/raven'
+    'mixen': '../../../components/mixen/mixen.min'
+    'vex': '../../../components/vex/js/vex'
+    'vex.dialog': '../../../components/vex/js/vex.dialog'
+    'modernizr': '../../../components/modernizr/modernizr'
+    'foundation': '../../../components/bower-foundation/js/foundation/foundation'
+    'foundation.tabs': '../../../components/bower-foundation/js/foundation/foundation.tab'
+    'foundation.topbar': '../../../components/bower-foundation/js/foundation/foundation.topbar'
+    'foundation.tooltip': '../../../components/bower-foundation/js/foundation/foundation.tooltip'
+    'foundation.alert': '../../../components/bower-foundation/js/foundation/foundation.alert'
+    'autolink': '../../../components/autolink/autolink-min'
+    'jquery.countdown': '../../../components/jquery.countdown/dist/jquery.countdown.min'
+    'jquery.payment': '../../../components/jquery.payment/lib/jquery.payment'
+    'slick': '../../../components/slick.js/slick/slick'
+    'animo': '../../../components/animo.js/animo'
+    'ladda': '../../../components/ladda/js/ladda'
+    'spin': '../../../components/ladda/js/spin'
+    'signet': '../../../components/signet/signet'
+    'messenger': '../../../components/messenger/build/js/messenger'
+    'select2': '../../../components/select2/select2'
+    'async': '../../../components/requirejs-plugins/src/async'
+    'jade.templates': '../../templates/jade'
 
   shim:
     underscore:
-      exports: "_"
+      exports: '_'
 
     backbone:
       deps: [
-        "jquery"
-        "underscore"
+        'jquery'
+        'underscore'
       ]
-      exports: "Backbone"
+      exports: 'Backbone'
 
     jade:
       deps: [
-        "moment"
+        'moment'
       ]
 
     raven:
-      exports: "Raven"
+      exports: 'Raven'
 
     humanize:
-      exports: "Humanize"
+      exports: 'Humanize'
 
     messenger:
       deps: [
-        "jquery"
+        'jquery'
       ]
-      exports: "Messenger"
+      exports: 'Messenger'
 
     select2:
       deps: [
-        "jquery"
+        'jquery'
       ]
-      exports: "Select2"
+      exports: 'Select2'
 
     foundation:
       deps: [
-        "jquery"
+        'jquery'
       ]
-      exports: "Foundation"
+      exports: 'Foundation'
 
-    "foundation.alert":
-      deps: ["foundation", "modernizr"]
+    'foundation.alert':
+      deps: ['foundation', 'modernizr']
 
-    "foundation.topbar":
-      deps: ["foundation"]
+    'foundation.topbar':
+      deps: ['foundation']
 
-    "foundation.tabs":
-      deps: ["foundation"]
+    'foundation.tabs':
+      deps: ['foundation']
 
-    "foundation.tooltip":
-      deps: ["foundation"]
+    'foundation.tooltip':
+      deps: ['foundation']
 
-    "jquery.payment":
-      deps: ["jquery"]
+    'jquery.payment':
+      deps: ['jquery']
 
     animo:
-      deps: ["jquery"]
-      exports: "animo"
+      deps: ['jquery']
+      exports: 'animo'
 
     ladda:
-      exports: "Ladda"
+      exports: 'Ladda'

--- a/static/src/styles/components/slick.sass
+++ b/static/src/styles/components/slick.sass
@@ -12,6 +12,10 @@ $slick-dot-size: 1.9rem
 
 @import "../../../components/slick.js/slick/slick-theme.scss"
 
+.slick-list
+    .slick-loading &
+      background-image: url(../../images/ajax-loader.gif)
+
 .slick-slider
   position: relative
 

--- a/static/src/styles/components/vex.sass
+++ b/static/src/styles/components/vex.sass
@@ -15,6 +15,9 @@ $blue: $primary-color
 
 @import "vex/vex-theme-default"
 
+.vex
+  padding-bottom: 0 !important
+
 .vex-content
   @include box-shadow(2px 2px 5px rgba(0, 0, 0, 0.3))
 
@@ -27,16 +30,20 @@ $blue: $primary-color
 .vex-content.padding-less
   padding: 0px !important
 
+@media #{$small-up}
+  .vex
+    padding-top: 55px !important
+
 @media #{$medium-up}
   .vex
-    padding-top: 120px
+    padding-top: 60px !important
 
   .vex-content.wide
     width: 600px
 
 @media #{$large-up}
   .vex
-    padding-top: 80px
+    padding-top: 80px !important
 
   .vex-content.wide
     width: 750px

--- a/static/src/styles/iframe.sass
+++ b/static/src/styles/iframe.sass
@@ -5,7 +5,9 @@
 @import "common/foundation"
 @import "common/topbar"
 
+@import "public/loading"
 @import "public/map"
+@import "public/universities"
 
 body, html
   padding: 0
@@ -16,15 +18,10 @@ body, html
   overflow: hidden
 
 #map-canvas
-  width: 100%
   height: 533px
-  line-height: 90%
   border-width: 0 2px 0 2px
   border-style: solid
   border-color: #D7D7D7
-
-  img
-    max-width: inherit
 
 #leaders
   height: 168px
@@ -38,3 +35,6 @@ body, html
   line-height: 45px
   vertical-align: middle
   font-size: 0.9rem
+
+.position
+  top: -5px

--- a/static/src/styles/public/admin.sass
+++ b/static/src/styles/public/admin.sass
@@ -18,10 +18,6 @@
   #map-canvas
     height: 380px
     margin-bottom: 20px
-    line-height: 90%
-
-    img
-      max-width: inherit
 
   #input-autocomplete
     margin: 15px 0 0 5px

--- a/static/src/styles/public/index.sass
+++ b/static/src/styles/public/index.sass
@@ -14,10 +14,6 @@ body, html
 
 #index-map-canvas
   height: 500px
-  line-height: 90%
-
-  img
-    max-width: inherit
 
 .winners
   text-align: center

--- a/static/src/styles/public/map.sass
+++ b/static/src/styles/public/map.sass
@@ -1,3 +1,8 @@
+.map
+  line-height: 90%
+
+  img
+    max-width: inherit
 
 .team-card
   margin-bottom: 30px 

--- a/static/src/styles/public/structure.sass
+++ b/static/src/styles/public/structure.sass
@@ -1,15 +1,12 @@
 .page-header
+  margin: 20px 0 30px
+  border-bottom: 1px solid $seperator-border-color
+
+.section-header
   margin: 0 0 12px
   border-bottom: 1px solid $seperator-border-color
 
-  button,
-  a.button
-    float: right 
-    padding: 0.5rem 0.8rem
-    margin: 0
-    @include border-radius(20px)
-
-.page-header-desc
+.section-header-desc
   margin-top: -10px
   color: $secondary-text-color
   margin-bottom: 20px

--- a/static/src/styles/public/structure.sass
+++ b/static/src/styles/public/structure.sass
@@ -32,3 +32,6 @@
 
 ul.items
   margin-left: 0
+
+.contains-table
+  overflow: scroll

--- a/static/src/styles/public/structure.sass
+++ b/static/src/styles/public/structure.sass
@@ -32,3 +32,6 @@
 .error-field
   border-color: #ff7076 !important
   @include box-shadow((inset 0 1px 2px rgba(0, 0, 0, 0), 0 1px 0 rgba(255, 255, 255, 0), 0 0 2px 0 rgba(255, 0, 0, 0.5) !important))
+
+ul.items
+  margin-left: 0

--- a/static/src/styles/public/team.sass
+++ b/static/src/styles/public/team.sass
@@ -187,6 +187,3 @@ $bar-text-color: $jb-light-grey
 #team-map
   height: 600px
   margin-bottom: 20px
-
-  img
-    max-width: inherit

--- a/static/src/styles/public/team.sass
+++ b/static/src/styles/public/team.sass
@@ -178,9 +178,15 @@ $bar-text-color: $jb-light-grey
   h3.page-header
     display: none
 
+  .team-header
+    display: none
+
+  .checkin i.fa
+    margin: 5px 0 0
+
 #team-map
   height: 600px
-  margin: 30px 0
+  margin-bottom: 20px
 
   img
     max-width: inherit

--- a/static/src/templates/admin/addCheckin.jade
+++ b/static/src/templates/admin/addCheckin.jade
@@ -1,5 +1,5 @@
 #add-checkin-panel
-  h3.page-header Add Checkin
+  h3.section-header Add Checkin
 
   form#checkin-form.clearfix
     input(type="text", placeholder="Give me a hint").radius#input-autocomplete

--- a/static/src/templates/admin/addCheckin.jade
+++ b/static/src/templates/admin/addCheckin.jade
@@ -3,7 +3,7 @@
 
   form#checkin-form.clearfix
     input(type="text", placeholder="Give me a hint").radius#input-autocomplete
-    #map-canvas
+    #map-canvas.map
 
     #position-inputs
       

--- a/static/src/templates/admin/addCheckinInputs.jade
+++ b/static/src/templates/admin/addCheckinInputs.jade
@@ -1,12 +1,12 @@
 .row
-  .small-2.columns
+  .small-12.medium-2.columns
     label(for="input-lat").right.inline Latitude
-  .small-4.columns
+  .small-12.medium-4.columns
     input(type="text", value="#{lat}").radius#input-lat
 
-  .small-2.columns
+  .small-12.medium-2.columns
     label(for="input-lon").right.inline Longitude
-  .small-4.columns
+  .small-12.medium-4.columns
     input(type="text", value="#{lon}").radius#input-lon
 
 label(for="input-location") Location

--- a/static/src/templates/admin/addDonate.jade
+++ b/static/src/templates/admin/addDonate.jade
@@ -1,7 +1,7 @@
 .row
   .small-12.columns
-    h3.page-header Add Donate Button
-    p.page-header-desc Inserts a donate button into the news feed. It can be for a specific team or the general JailbreakHQ pot
+    h3.page-header Admin: Add Donate Button
+    p.section-header-desc Inserts a donate button into the news feed. It can be for a specific team or the general JailbreakHQ pot
 
 .row
   .small-12.medium-6.columns

--- a/static/src/templates/admin/addLink.jade
+++ b/static/src/templates/admin/addLink.jade
@@ -1,7 +1,7 @@
 .row
   .small-12.columns
     h3.page-header Add Link
-    p.page-header-desc This very generic feed item is great for linking to things other than supported social content or donate buttons
+    p.section-header-desc This very generic feed item is great for linking to things other than supported social content or donate buttons
 
 .row
   .small-12.medium-6.columns

--- a/static/src/templates/admin/addSocial.jade
+++ b/static/src/templates/admin/addSocial.jade
@@ -1,7 +1,7 @@
 .row
   .small-12.columns
-    h3.page-header Add Social Item
-    p.page-header-desc Embed content from Twitter, Facebook, Youtube, Instagram, Vine into the news feed
+    h3.section-header Add Social Item
+    p.section-header-desc Embed content from Twitter, Facebook, Youtube, Instagram, Vine into the news feed
 
 .row
   .small-12.medium-6.columns

--- a/static/src/templates/admin/main.jade
+++ b/static/src/templates/admin/main.jade
@@ -5,7 +5,7 @@
 
   .row
     .small-12.columns
-      h3.page-header Checkins Dashboard
+      h3.section-header Checkins Dashboard
       table
         thead
           th

--- a/static/src/templates/admin/main.jade
+++ b/static/src/templates/admin/main.jade
@@ -4,7 +4,7 @@
       h1.page-header Admin Panel
 
   .row
-    .small-12.columns
+    .small-12.columns.contains-table
       h3.section-header Checkins Dashboard
       table
         thead

--- a/static/src/templates/donations.jade
+++ b/static/src/templates/donations.jade
@@ -1,6 +1,6 @@
 include mixins.jade
 
-h3.page-header Recent Donations!
+h3.section-header Recent Donations!
 
 if error
   +alert("recent donations". errorMessage, errorStatus)

--- a/static/src/templates/donations.jade
+++ b/static/src/templates/donations.jade
@@ -1,20 +1,28 @@
-h3.page-header.show-for-large-up Recent Donations
-ul#donations.donations-list
-  each donation in donations
-    li
-      span
-        em &euro;
-          = Humanize.intComma(donation.amount/100)
-        |  from #{donation.name} 
-        if donation.team
-          | to 
-          a(href="/teams/#{donation.team.slug}") #{donation.team.names} 
-          
-      span.time
-        = moment(donation.time*1000).fromNow()
-  else
-    span There are no donations yet! Why don't you help us out? 
-      a(href="#").donate-button Donate
+include mixins.jade
 
-if totalCount > donations.length
-  p.and-more and #{totalCount-donations.length} other donations
+h3.page-header Recent Donations!
+
+if error
+  +alert("recent donations". errorMessage, errorStatus)
+else if !loaded
+  include loading.jade
+else
+  ul#donations.donations-list
+    each donation in donations
+      li
+        span
+          em &euro;
+            = Humanize.intComma(donation.amount/100)
+          |  from #{donation.name} 
+          if donation.team
+            | to 
+            a(href="/teams/#{donation.team.slug}") #{donation.team.names} 
+            
+        span.time
+          = moment(donation.time*1000).fromNow()
+    else
+      span There are no donations yet! Why don't you help us out? 
+        a(href="#").donate-button Donate
+
+  if totalCount > donations.length
+    p.and-more and #{totalCount-donations.length} other donations

--- a/static/src/templates/error-404.jade
+++ b/static/src/templates/error-404.jade
@@ -1,10 +1,10 @@
-.row
-  .small-12.columns
-    .error-container
-      h2.page-header Page Not Found
-      p The page you were looking for does not exist. Do you want to go 
-        a(href="/")
-          | back to the home page
-        | ?
+include mixins.jade
 
-      #broken-glass
++errorContainer
+  h2.page-header Page Not Found
+  p The page you were looking for does not exist. Do you want to go 
+    a(href="/")
+      | back to the home page
+    | ?
+
+  #broken-glass

--- a/static/src/templates/feed/checkin.jade
+++ b/static/src/templates/feed/checkin.jade
@@ -1,6 +1,6 @@
 .feed-item.checkin
-  p
-    i.fa.fa-globe
+  i.fa.fa-globe
+  span.team-header
     if team.avatar
       img(src="#{team.avatar}", width="30", height="30").radius
     h4
@@ -9,11 +9,11 @@
         span.label.round(class="#{team.university.toLowerCase()}") #{team.university}
         span.label.round
             = Humanize.ordinal(team.position)
-    span.time
-      if locals.time
-        = moment(time*1000).fromNow()
-      else
-        = moment().fromNow()
-    p 
-      strong #{location}: 
-      | #{status}
+  span.time
+    if locals.time
+      = moment(time*1000).fromNow()
+    else
+      = moment().fromNow()
+  p 
+    strong #{location}: 
+    | #{status}

--- a/static/src/templates/feed/list.jade
+++ b/static/src/templates/feed/list.jade
@@ -1,6 +1,6 @@
 include ../mixins.jade
 
-h3.page-header Updates from Jailbreak 2015
+h3.section-header Updates from Jailbreak 2015
 
 if error
   +alert("highlights", errorMessage, errorStatus)

--- a/static/src/templates/feed/list.jade
+++ b/static/src/templates/feed/list.jade
@@ -1,3 +1,10 @@
+include ../mixins.jade
+
 h3.page-header Updates from Jailbreak 2015
 
-ul#events-stream-list
+if error
+  +alert("highlights", errorMessage, errorStatus)
+else if !loaded
+  include ../loading.jade
+else
+  ul#events-stream-list.items

--- a/static/src/templates/iframe/leaders.jade
+++ b/static/src/templates/iframe/leaders.jade
@@ -1,0 +1,8 @@
+include ../mixins.jade
+
+if error
+  +alert("top teams list", errorMessage, errorStatus)
+else if !loaded
+  include ../loading.jade
+else
+  #leaders-list

--- a/static/src/templates/index.jade
+++ b/static/src/templates/index.jade
@@ -1,6 +1,6 @@
 .row
   .small-12.columns.padding-less
-    #index-map-canvas
+    #index-map-canvas.map
 .cta-box
   .row
     .small-12.columns

--- a/static/src/templates/index.jade
+++ b/static/src/templates/index.jade
@@ -22,8 +22,8 @@
     ul#all-donations.donations-list
 .row
   .small-12.columns
-    h3.page-header Featured Jailbreak Videos
-    p.page-header-desc Here are some of our favourite videos
+    h3.section-header Featured Jailbreak Videos
+    p.section-header-desc Here are some of our favourite videos
     .video-slick
       div
         a.th.radius(href="https://www.youtube.com/watch?v=MW5DhQPTqMY", target="_blank").video

--- a/static/src/templates/index.jade
+++ b/static/src/templates/index.jade
@@ -30,6 +30,10 @@
           img(src="//static.jailbreakhq.org/video/promo-video.png", height=250)
           h5 Announcing Jailbreak 2015
       div
+        a.th.radius(href="https://www.youtube.com/watch?v=zQxTo9NQ5zc", target="_blank").video
+          img(src="//static.jailbreakhq.org/video/about-jailbreak-video.png", height=250)
+          h5 Jailbreak 2015 in 90 Seconds
+      div
         a.th.radius(href="https://www.youtube.com/watch?v=_W_4x8q0fiE", target="_blank").video
           img(src="//static.jailbreakhq.org/video/team-75-video.png", height=250)
           h5 Top and Bottom

--- a/static/src/templates/login.jade
+++ b/static/src/templates/login.jade
@@ -1,7 +1,7 @@
 #login-background
 
   #login-panel
-    h3.page-header Login
+    h3.section-header Login
 
     form#login-form
       input(type="email", placeholder="email@example.com").radius#input-email

--- a/static/src/templates/mapsCheckinMarker.jade
+++ b/static/src/templates/mapsCheckinMarker.jade
@@ -1,4 +1,6 @@
 .info-window
   span.time
     = moment(time*1000).fromNow()
-  p #{status}
+  p 
+    strong #{location}: 
+    | #{status}

--- a/static/src/templates/mixins.jade
+++ b/static/src/templates/mixins.jade
@@ -1,0 +1,17 @@
+
+mixin errorContainer
+  .row
+    .small-12.columns
+      .error-container
+        block
+
+mixin alert(resource, message, status)
+  .alert-box.alert.round
+    if status == 503
+      | The #{resource} is temporarily unavilable please try again soon
+    else if status == 404
+      | The #{resource} you were looking for was not found. Bummer. 
+      a(href="/") Go to home page
+    else
+      | There was a problem loading the #{resource}: #{message} 
+      small (#{status})

--- a/static/src/templates/team.jade
+++ b/static/src/templates/team.jade
@@ -1,18 +1,47 @@
-#team
-  #header.row.collapse-small
-    .blurred(style="background-image: url(#{avatar})")
-    .header-content
-      if avatarLarge
-        a.th.radius.team-avatar.avatar-large
-          img(src="#{avatar}", width=200, height=200)
-      else
-         .th.radius.team-avatar
-          img(src="#{avatar}", width=200, height=200)
-      .text
-        h2 #{names}
-        h4 #{teamName}
-        p.show-for-medium-up #{tagLine}
-        ul.show-for-medium-up
+include mixins.jade
+
+if error
+  +errorContainer
+    h2.page-header Team Not Found
+    +alert("team", errorMessage, errorStatus)
+    #broken-glass
+else if !loaded
+  include loading.jade
+else
+  #team
+    #header.row.collapse-small
+      .blurred(style="background-image: url(#{avatar})")
+      .header-content
+        if avatarLarge
+          a.th.radius.team-avatar.avatar-large
+            img(src="#{avatar}", width=200, height=200)
+        else
+           .th.radius.team-avatar
+            img(src="#{avatar}", width=200, height=200)
+        .text
+          h2 #{names}
+          h4 #{teamName}
+          p.show-for-medium-up #{tagLine}
+          ul.show-for-medium-up
+            li 
+              h6 Team No.
+              span.value #{teamNumber}
+            li 
+              h6 University
+              span.value #{university}
+            li
+              h6 Raised
+              span.value &euro;
+                = Humanize.intComma((amountRaisedOnline+amountRaisedOffline)/100)
+          a.button.round.donate-button.show-for-medium-up Donate Now
+      .hide-blur
+
+    .row.bar.hide-for-medium-up
+      .small-12.medium-4.columns
+        h6.bio  Bio
+        p.tag-line #{tagLine}
+      .small-12.medium-8.columns
+        ul.small-block-grid-3.medium-block-grid-4
           li 
             h6 Team No.
             span.value #{teamNumber}
@@ -22,61 +51,42 @@
           li
             h6 Raised
             span.value &euro;
-              = Humanize.intComma((amountRaisedOnline+amountRaisedOffline)/100)
-        a.button.round.donate-button.show-for-medium-up Donate Now
-    .hide-blur
+            = Humanize.intComma((amountRaisedOnline+amountRaisedOffline)/100)
+      .small-12.columns
+        a.button.round.expand.donate-button.show-for-small-only Donate Now
 
-  .row.bar.hide-for-medium-up
-    .small-12.medium-4.columns
-      h6.bio  Bio
-      p.tag-line #{tagLine}
-    .small-12.medium-8.columns
-      ul.small-block-grid-3.medium-block-grid-4
-        li 
-          h6 Team No.
-          span.value #{teamNumber}
-        li 
-          h6 University
-          span.value #{university}
-        li
-          h6 Raised
-          span.value &euro;
-          = Humanize.intComma((amountRaisedOnline+amountRaisedOffline)/100)
-    .small-12.columns
-      a.button.round.expand.donate-button.show-for-small-only Donate Now
+    .row
+      .small-12.columns.no-padding
+        ul.tabs(data-tab).hide-for-large-up
+          li.tab-title.active
+            a(href="#story-panel") Story
+          li.tab-title
+            a(href="#about-panel") About
+          li.tab-title
+            a(href="#donations-panel") Donations
+        .tabs-content
+          .content.active#story-panel
+            .row
+              .small-12.columns
+                h3.page-header Our Jailbreak Story
+            .row
+              .small-12.large-7.columns
+                #team-map
+              .small-12.large-5.columns
+                #team-story
+          .content#about-panel
+            h3.page-header.show-for-large-up About #{names}
+            if locals.description
+              != _.escape(description).autoLink().split("\n").join("<br />")
+            else
+              | This team has not written about themselves yet. 
 
-  .row
-    .small-12.columns.no-padding
-      ul.tabs(data-tab).hide-for-large-up
-        li.tab-title.active
-          a(href="#story-panel") Story
-        li.tab-title
-          a(href="#about-panel") About
-        li.tab-title
-          a(href="#donations-panel") Donations
-      .tabs-content
-        .content.active#story-panel
-          .row
-            .small-12.columns
-              h3.page-header Our Jailbreak Story
-          .row
-            .small-12.large-7.columns
-              #team-map
-            .small-12.large-5.columns
-              #team-story
-        .content#about-panel
-          h3.page-header.show-for-large-up About #{names}
-          if locals.description
-            != _.escape(description).autoLink().split("\n").join("<br />")
-          else
-            | This team has not written about themselves yet. 
-
-          if locals.video
-            h3.video Video
-            .about-video
-              if video.indexOf('facebook') != -1
-                != video
-              else
-                .flex-video
+            if locals.video
+              h3.video Video
+              .about-video
+                if video.indexOf('facebook') != -1
                   != video
-        .content#donations-panel
+                else
+                  .flex-video
+                    != video
+          .content#donations-panel

--- a/static/src/templates/team.jade
+++ b/static/src/templates/team.jade
@@ -71,7 +71,7 @@ else
                 h3.section-header Our Jailbreak Story
             .row
               .small-12.large-7.columns
-                #team-map
+                #team-map.map
               .small-12.large-5.columns
                 #team-story
           .content#about-panel

--- a/static/src/templates/team.jade
+++ b/static/src/templates/team.jade
@@ -68,14 +68,14 @@ else
           .content.active#story-panel
             .row
               .small-12.columns
-                h3.page-header Our Jailbreak Story
+                h3.section-header Our Jailbreak Story
             .row
               .small-12.large-7.columns
                 #team-map
               .small-12.large-5.columns
                 #team-story
           .content#about-panel
-            h3.page-header.show-for-large-up About #{names}
+            h3.section-header.show-for-large-up About #{names}
             if locals.description
               != _.escape(description).autoLink().split("\n").join("<br />")
             else

--- a/static/src/templates/teamCard.jade
+++ b/static/src/templates/teamCard.jade
@@ -2,11 +2,15 @@
   .row.collapse.team-card
     .small-5.columns
       .profile
-        a(href="https://jailbreakhq.org/teams/#{slug}").th
+        a(href="https://jailbreakhq.org/teams/#{slug}").th.radius
           img(width="125", height="125", src="#{avatar}")
     .small-7.columns
       h3 
-        a(href="https://jailbreakhq.org/teams/#{slug}") #{names}
+        a(href="https://jailbreakhq.org/teams/#{slug}")
+          | #{names}
+          span.label.round.position
+            = Humanize.ordinal(position)
+          span.label.round.position(class="#{university.toLowerCase()}") #{university}
       h4 #{teamName}
       if locals.lastCheckin
         strong #{lastCheckin.location}

--- a/static/src/templates/teamDonations.jade
+++ b/static/src/templates/teamDonations.jade
@@ -1,4 +1,4 @@
-h3.page-header.show-for-large-up Recent Donations
+h3.section-header.show-for-large-up Recent Donations
 ul#donations.donations-list
   each donation in donations
     li

--- a/static/src/templates/teams.jade
+++ b/static/src/templates/teams.jade
@@ -1,7 +1,11 @@
+include mixins.jade
+
 .row
   .small-12.columns
     h2.page-header Teams
-    if loaded
-      ul#teams.teams-list.small-block-grid-1.medium-block-grid-3.large-block-grid-4
-    else
+    if error
+      +alert("teams list", errorMessage, errorStatus)
+    else if !loaded
       include loading.jade
+    else
+      ul#teams.teams-list.small-block-grid-1.medium-block-grid-3.large-block-grid-4


### PR DESCRIPTION
Also fixed
- Moved html source files into the `src` directory
- Fixed vex scrolling issues on mobile screens
- Increased google analytics script load timeout to reduce javascript errors
- `RequiresLoginMixin` now checks the `apiToken` expires value to see if we need to log the user back in again
- Added jade mixins to handle alerts and error containers
- Created distinction between `.page-header` and `.section-header` classes so that page headers have more margin around them than section headers
- Changed to using the coffeescript single quotes convention
- Created base collection and model view mixins
- Create base view mixin
- Fixed mixins to not call super in the constructor/initialize (worst small print in the HubSpot mixin documentation caused subtle bugs)
- Team profile doesn't show any content until at least the team model has been loaded from the API -- reduces jank
- Create sub view rendering pattern to reduce the number of renders that take place on sub views
- Added loading animations, error handling and position UI changes to the iframe code.
- Refactored the messy common google maps CSS by adding a `.map` class with common styles
- Other minor fixes that are detailed in the individual commit descriptions
